### PR TITLE
Force "en" locale on test windows

### DIFF
--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -40,7 +40,8 @@ require.config({
         "*": {
             "thirdparty/react": "react"
         }
-    }
+    },
+    locale: "en" // force English (US)
 });
 
 define(function (require, exports, module) {


### PR DESCRIPTION
Before some tests failed because they were using the wrong locale