### PR TITLE
Add a setTimeout in a FindInFile test

### DIFF
--- a/test/spec/FindInFiles-test.js
+++ b/test/spec/FindInFiles-test.js
@@ -2307,7 +2307,9 @@ define(function (require, exports, module) {
                             waitsForDone(promisify(FileSystem.getFileForPath(testPath + "/foo.html"), "write", "changed content"));
                         });
                         runs(function () {
-                            expect($("#find-in-files-results").is(":visible")).toBe(false);
+                            setTimeout(function () {
+                                expect($("#find-in-files-results").is(":visible")).toBe(false);
+                            }, 120);
                         });
                     });
 


### PR DESCRIPTION
I think the setTimeout is necessary because of https://github.com/quadre-code/quadre/commit/94ed8b3d42707a652cb3b6279deb73aceadc7570 which changed how the file events are fired: not more immediately but after a bit of time.
