### PR TITLE
Make sure also dot files are copied for src

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,7 @@ function copyJs(filePath, srcDir, distDir) {
 gulp.task('copy-src-dist', (_cb) => {
     const cb = _.after(BASE_DIRS.length, _cb);
     BASE_DIRS.forEach((srcDir, idx) => {
-        gulp.src(`${srcDir}/**/!(*.ts|*.tsx)`)
+        gulp.src(`${srcDir}/**/!(*.ts|*.tsx)`, { dot: true })
             .pipe(gulp.dest(DIST_DIRS[idx]))
             .on('end', cb);
     });


### PR DESCRIPTION
Without it some JSLint extension tests were failing because a file
(.brackets.json) wasn't copied.