### PR TITLE
Update jasmine junit reporter to version 1.1.0

### DIFF
--- a/test/thirdparty/jasmine-reporters/README.markdown
+++ b/test/thirdparty/jasmine-reporters/README.markdown
@@ -1,23 +1,27 @@
+This branch is for Jasmine 1.x.
+[Switch to the 2.x branch.](https://github.com/larrymyers/jasmine-reporters)
+
 # Jasmine Reporters
 
 Jasmine Reporters is a collection of javascript jasmine.Reporter classes that can be used with
-the [JasmineBDD testing framework](http://pivotal.github.com/jasmine/).
+the [JasmineBDD testing framework](http://jasmine.github.io/).
 
 Included reporters:
 
 * ConsoleReporter - Report test results to the browser console.
-* JUnitXmlReporter - Report test results to a file (using Rhino or PyPhantomJS) in JUnit XML Report format.
+* JUnitXmlReporter - Report test results to a file in JUnit XML Report format.
+* NUnitXmlReporter - Report test results to a file in NUnit XML Report format.
 * TapReporter - Test Anything Protocol, report tests results to console.
 * TeamcityReporter - Basic reporter that outputs spec results to for the Teamcity build system.
-
+* TerminalReporter - Logs to a terminal (including colors) with variable verbosity.
 
 ## Usage
 
 Examples are included in the test directory that show how to use the reporters,
-as well a basic runner scripts for Rhino + envjs, and a basic runner for 
-[PhantomJS](https://github.com/ariya/phantomjs) (using PyPhantomJS and the
-saveToFile plugin). Either of these methods could be used in a Continuous
-Integration project for running headless tests and generating JUnit XML output.
+as well a basic runner scripts for Rhino + envjs, and a basic runner for
+[PhantomJS](https://github.com/ariya/phantomjs). Either of these methods could
+be used in a Continuous Integration project for running headless tests and
+generating JUnit XML output.
 
 ### Rhino + EnvJS
 
@@ -25,31 +29,31 @@ Everything needed to run the tests in Rhino + EnvJS is included in this
 repository inside the `ext` directory, specifically Rhino 1.7r2 and envjs 1.2
 for Rhino.
 
-### PhantomJS, PyPhantomJS
+### PhantomJS
 
-PhantomJS is included as a submodule inside the `ext` directory. The included
-example runner makes use of PyPhantomJS to execute the headless tests and
-save XML output to the filesystem.
+Should work in most versions of PhantomJS > 1.4.1
+I have used PhantomJS 1.4.1 through 1.9.6 on Mac OS X with no problems.
 
-While PhantomJS and PyPhantomJS both run on MacOS / Linux / Windows, there are
-specific dependencies for each platform. Specifics on installing these are not
-included here, but is left as an exercise for the reader. The [PhantomJS](https://github.com/ariya/phantomjs)
-project contains links to various documentation, including installation notes.
+### Node.js
 
-Here is how I got it working in MacOSX 10.6 (YMMV):
+Most of these reporters also work in node.js by making use of the excellent
+[jasmine-node project](https://github.com/mhevery/jasmine-node).
 
-* ensure you are using Python 2.6+
-* install Xcode (this gives you make, et al)
-* install qt (this gives you qmake, et al)
-  * this may be easiest via [homebrew](https://github.com/mxcl/homebrew)
-  * `brew install qt`
-* install the python sip module
-  * `pip install sip # this will fail to fully install sip, keep going`
-  * `cd build/sip`
-  * `python configure.py`
-  * `make && sudo make install`
-* install the python pyqt module
-  * `pip install pyqt # this will fail to fully install pyqt, keep going`
-  * `cd build/pyqt`
-  * `python configure.py`
-  * `make && sudo make install`
+# Protractor
+
+Protractor 1.6.0 or above allows you to use either Jasmine 1 or Jasmine 2.
+If you are using Jasmine 1, make sure you install a 1.x-compatible version of jasmine-reporters:
+
+    npm install --save-dev jasmine-reporters@^1.0.0
+
+Then set everything up inside your protractor.conf:
+
+    onPrepare: function() {
+        // The require statement must be down here, since jasmine-reporters@1.0
+        // expects jasmine to be in the global and protractor does not guarantee
+        // this until inside the onPrepare function.
+        require('jasmine-reporters');
+        jasmine.getEnv().addReporter(
+            new jasmine.JUnitXmlReporter('xmloutput', true, true)
+        );
+    }


### PR DESCRIPTION
Previously uploading the junit xml to appveyor failed because some
stacktraces where not escaped correctly.
They could contain something like `<anonymous>` instead of
`&lt;anonymous&gt;`

https://github.com/larrymyers/jasmine-reporters/tree/1.1.0