### PR TITLE
Verify waitsFor(Done|Fail) are called inside a runs function

### DIFF
--- a/src/extensions/default/HealthData/unittests.js
+++ b/src/extensions/default/HealthData/unittests.js
@@ -79,25 +79,35 @@ define(function (require, exports, module) {
                 var baseTime = Date.now();
                 PreferencesManager.setViewState("nextHealthDataSendTime", baseTime);
                 PreferencesManager.setViewState("healthDataNotificationShown", true);
-                var promise = HealthDataManager.checkHealthDataSend();
-                waitsForDone(promise, "Send Data to Server", 4000);
-                expect(PreferencesManager.getViewState("nextHealthDataSendTime")).toBeGreaterOrEqualTo(baseTime + ONE_DAY);
+                runs(function () {
+                    var promise = HealthDataManager.checkHealthDataSend();
+                    waitsForDone(promise, "Send Data to Server", 4000);
+                });
+                runs(function () {
+                    expect(PreferencesManager.getViewState("nextHealthDataSendTime")).toBeGreaterOrEqualTo(baseTime + ONE_DAY);
+                });
             });
 
             it("should not send data right away on first launch", function () {
                 var baseTime = Date.now();
                 PreferencesManager.setViewState("nextHealthDataSendTime", null);
                 PreferencesManager.setViewState("healthDataNotificationShown", true);
-                var promise = HealthDataManager.checkHealthDataSend();
-                waitsForFail(promise, "Send Data to Server", 4000);
-                expect(PreferencesManager.getViewState("nextHealthDataSendTime")).toBeGreaterOrEqualTo(baseTime + FIRST_LAUNCH_SEND_DELAY);
+                runs(function () {
+                    var promise = HealthDataManager.checkHealthDataSend();
+                    waitsForFail(promise, "Send Data to Server", 4000);
+                });
+                runs(function () {
+                    expect(PreferencesManager.getViewState("nextHealthDataSendTime")).toBeGreaterOrEqualTo(baseTime + FIRST_LAUNCH_SEND_DELAY);
+                });
             });
 
             it("should not send data to server when opted out", function () {
                 PreferencesManager.setViewState("nextHealthDataSendTime", Date.now());
                 prefs.set("healthDataTracking", false);
-                var promise = HealthDataManager.checkHealthDataSend();
-                waitsForFail(promise, "Send Data to Server", 4000);
+                runs(function () {
+                    var promise = HealthDataManager.checkHealthDataSend();
+                    waitsForFail(promise, "Send Data to Server", 4000);
+                });
             });
 
         });

--- a/src/extensions/default/JSLint/unittests.js
+++ b/src/extensions/default/JSLint/unittests.js
@@ -73,7 +73,9 @@ define(function (require, exports, module) {
                 spyOn(testWindow, "JSLINT").andCallThrough();
             });
 
-            waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+            runs(function () {
+                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+            });
 
             runs(function () {
                 expect(testWindow.JSLINT).toHaveBeenCalled();
@@ -81,8 +83,9 @@ define(function (require, exports, module) {
         });
 
         it("status icon should toggle Errors panel when errors present", function () {
-            waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
-
+            runs(function () {
+                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+            });
             runs(function () {
                 toggleJSLintResults(false);
                 toggleJSLintResults(true);
@@ -90,7 +93,9 @@ define(function (require, exports, module) {
         });
 
         it("status icon should not toggle Errors panel when no errors present", function () {
-            waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js"]), "open test file");
+            runs(function () {
+                waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js"]), "open test file");
+            });
 
             runs(function () {
                 toggleJSLintResults(false);
@@ -99,7 +104,9 @@ define(function (require, exports, module) {
         });
 
         it("should default to the editor's indent", function () {
-            waitsForDone(SpecRunnerUtils.openProjectFiles(["different-indent.js"]), "open test file");
+            runs(function () {
+                waitsForDone(SpecRunnerUtils.openProjectFiles(["different-indent.js"]), "open test file");
+            });
 
             runs(function () {
                 toggleJSLintResults(false);

--- a/test/spec/CodeInspection-test.js
+++ b/test/spec/CodeInspection-test.js
@@ -553,7 +553,9 @@ define(function (require, exports, module) {
                 var codeInspector = createCodeInspector("javascript linter", failLintResult());
                 CodeInspection.register("javascript", codeInspector);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                });
 
                 runs(function () {
                     expect($("#problems-panel").is(":visible")).toBe(true);
@@ -568,10 +570,17 @@ define(function (require, exports, module) {
                 var asyncProvider = makeAsyncLinter();
                 CodeInspection.register("javascript", asyncProvider);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js", "errors.js"]), "open test files");
+                var errorsJS,
+                    noErrorsJS;
 
-                var errorsJS   = SpecRunnerUtils.makeAbsolute("errors.js"),
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js", "errors.js"]), "open test files");
+                });
+
+                runs(function () {
+                    errorsJS   = SpecRunnerUtils.makeAbsolute("errors.js");
                     noErrorsJS = SpecRunnerUtils.makeAbsolute("no-errors.js");
+                });
 
                 runs(function () {
                     // Start linting the first file
@@ -603,9 +612,15 @@ define(function (require, exports, module) {
                 var asyncProvider = makeAsyncLinter();
                 CodeInspection.register("javascript", asyncProvider);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js"]), "open test files");
+                var noErrorsJS;
 
-                var noErrorsJS = SpecRunnerUtils.makeAbsolute("no-errors.js");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js"]), "open test files");
+                });
+
+                runs(function () {
+                    noErrorsJS = SpecRunnerUtils.makeAbsolute("no-errors.js");
+                });
 
                 runs(function () {
                     // Start linting the file
@@ -632,9 +647,15 @@ define(function (require, exports, module) {
                 var asyncProvider = makeAsyncLinter();
                 CodeInspection.register("javascript", asyncProvider);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js"]), "open test files");
+                var noErrorsJS;
 
-                var noErrorsJS = SpecRunnerUtils.makeAbsolute("no-errors.js");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js"]), "open test files");
+                });
+
+                runs(function () {
+                    noErrorsJS = SpecRunnerUtils.makeAbsolute("no-errors.js");
+                });
 
                 runs(function () {
                     // Start linting the file
@@ -661,9 +682,15 @@ define(function (require, exports, module) {
                 var asyncProvider = makeAsyncLinter();
                 CodeInspection.register("javascript", asyncProvider);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js"]), "open test files");
+                var noErrorsJS;
 
-                var noErrorsJS = SpecRunnerUtils.makeAbsolute("no-errors.js");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js"]), "open test files");
+                });
+
+                runs(function () {
+                    noErrorsJS = SpecRunnerUtils.makeAbsolute("no-errors.js");
+                });
 
                 runs(function () {
                     // Start linting the file
@@ -699,7 +726,9 @@ define(function (require, exports, module) {
                 var codeInspector = createCodeInspector("javascript linter", lintResult);
                 CodeInspection.register("javascript", codeInspector);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                });
 
                 runs(function () {
                     expect($("#problems-panel").is(":visible")).toBe(true);
@@ -718,7 +747,9 @@ define(function (require, exports, module) {
                 var codeInspector = createCodeInspector("javascript linter", failLintResult());
                 CodeInspection.register("javascript", codeInspector);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                });
 
                 runs(function () {
                     expect(codeInspector.scanFile).not.toHaveBeenCalled();
@@ -734,7 +765,9 @@ define(function (require, exports, module) {
                 var codeInspector = createCodeInspector("javascript linter", {errors: []});
                 CodeInspection.register("javascript", codeInspector);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                });
 
                 runs(function () {
                     expect($("#problems-panel").is(":visible")).toBe(false);
@@ -747,7 +780,9 @@ define(function (require, exports, module) {
                 var codeInspector = createCodeInspector("javascript linter", null);
                 CodeInspection.register("javascript", codeInspector);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                });
 
                 runs(function () {
                     expect($("#problems-panel").is(":visible")).toBe(false);
@@ -762,7 +797,9 @@ define(function (require, exports, module) {
                 CodeInspection.register("javascript", codeInspector1);
                 CodeInspection.register("javascript", codeInspector2);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                });
 
                 runs(function () {
                     var $inspectorSections = $(".inspector-section td");
@@ -783,7 +820,9 @@ define(function (require, exports, module) {
                 CodeInspection.register("javascript", codeInspector2);
                 CodeInspection.register("javascript", codeInspector3);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                });
 
                 runs(function () {
                     expect($("#problems-panel").is(":visible")).toBe(true);
@@ -801,7 +840,9 @@ define(function (require, exports, module) {
                 CodeInspection.register("javascript", codeInspector3);
                 CodeInspection.register("javascript", codeInspector4);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file", 5000);
+                });
 
                 runs(function () {
                     expect($("#problems-panel").is(":visible")).toBe(true);
@@ -817,7 +858,9 @@ define(function (require, exports, module) {
                 var codeInspector = createCodeInspector("javascript linter", failLintResult());
                 CodeInspection.register("javascript", codeInspector);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                });
 
                 runs(function () {
                     toggleJSLintResults(false);
@@ -829,7 +872,9 @@ define(function (require, exports, module) {
                 var codeInspector = createCodeInspector("javascript linter", successfulLintResult());
                 CodeInspection.register("javascript", codeInspector);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js"]), "open test file");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js"]), "open test file");
+                });
 
                 runs(function () {
                     toggleJSLintResults(false);
@@ -841,7 +886,9 @@ define(function (require, exports, module) {
                 var codeInspector = createCodeInspector("JavaScript Linter", failLintResult());
                 CodeInspection.register("javascript", codeInspector);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                });
 
                 runs(function () {
                     var $problemPanelTitle = $("#problems-panel .title").text();
@@ -875,7 +922,9 @@ define(function (require, exports, module) {
                 var codeInspector = createCodeInspector("JavaScript Linter", lintResult);
                 CodeInspection.register("javascript", codeInspector);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                });
 
                 runs(function () {
                     var $problemPanelTitle = $("#problems-panel .title").text();
@@ -898,7 +947,9 @@ define(function (require, exports, module) {
                 var codeInspector2 = createCodeInspector("JavaScript Linter2", lintResult);
                 CodeInspection.register("javascript", codeInspector2);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                });
 
                 runs(function () {
                     var $problemPanelTitle = $("#problems-panel .title").text();
@@ -920,7 +971,9 @@ define(function (require, exports, module) {
                 codeInspector = createCodeInspector("JavaScript Linter2", successfulLintResult());
                 CodeInspection.register("javascript", codeInspector);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                });
 
                 runs(function () {
                     var $statusBar = $("#status-inspection");
@@ -936,7 +989,9 @@ define(function (require, exports, module) {
                 var codeInspector = createCodeInspector("JavaScript Linter1", successfulLintResult());
                 CodeInspection.register("javascript", codeInspector);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                });
 
                 runs(function () {
                     var $statusBar = $("#status-inspection");
@@ -952,7 +1007,9 @@ define(function (require, exports, module) {
                 var codeInspector = createCodeInspector("javascript linter", failLintResult());
                 CodeInspection.register("javascript", codeInspector);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                });
 
                 runs(function () {
                     CommandManager.execute(Commands.NAVIGATE_GOTO_FIRST_PROBLEM);
@@ -982,7 +1039,9 @@ define(function (require, exports, module) {
                 CodeInspection.register("javascript", codeInspector1);
                 CodeInspection.register("javascript", codeInspector2);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                });
 
                 runs(function () {
                     CommandManager.execute(Commands.NAVIGATE_GOTO_FIRST_PROBLEM);
@@ -1014,7 +1073,9 @@ define(function (require, exports, module) {
                 CodeInspection.register("javascript", codeInspector1);
                 CodeInspection.register("javascript", codeInspector2);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                });
 
                 runs(function () {
                     var $problemPanelTitle = $("#problems-panel .title").text();
@@ -1047,7 +1108,9 @@ define(function (require, exports, module) {
 
                 CodeInspection.register("javascript", codeInspectorToTimeout);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                });
 
                 waits(prefs.get(CodeInspection._PREF_ASYNC_TIMEOUT) + 20);
 
@@ -1081,7 +1144,9 @@ define(function (require, exports, module) {
 
                 CodeInspection.register("javascript", buggyAsyncProvider);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                });
 
                 runs(function () {
                     var $problemsPanel = $("#problems-panel");
@@ -1109,7 +1174,9 @@ define(function (require, exports, module) {
 
                 CodeInspection.register("javascript", buggySyncProvider);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                });
 
                 runs(function () {
                     var $problemsPanel = $("#problems-panel");
@@ -1138,7 +1205,9 @@ define(function (require, exports, module) {
                     expected += registrationOrder[i].name + " " + "(1) ";
                 }
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["errors.js"]), "open test file");
+                });
 
                 waits(410);
 
@@ -1162,7 +1231,9 @@ define(function (require, exports, module) {
                 var codeInspector2 = createCodeInspector("javascript inspector 2", successfulLintResult());
                 CodeInspection.register("javascript", codeInspector2);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js"]), "open test file", 5000);
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js"]), "open test file", 5000);
+                });
 
                 runs(function () {
                     expect(codeInspector1.scanFile).toHaveBeenCalled();
@@ -1176,7 +1247,9 @@ define(function (require, exports, module) {
                 var codeInspector2 = createCodeInspector("javascript inspector 2", successfulLintResult());
                 CodeInspection.register("javascript", codeInspector2, true);
 
-                waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js"]), "open test file", 5000);
+                runs(function () {
+                    waitsForDone(SpecRunnerUtils.openProjectFiles(["no-errors.js"]), "open test file", 5000);
+                });
 
                 runs(function () {
                     expect(codeInspector1.scanFile).toHaveBeenCalled();

--- a/test/spec/ExtensionInstallation-test.js
+++ b/test/spec/ExtensionInstallation-test.js
@@ -136,8 +136,10 @@ define(function (require, exports, module) {
         afterEach(function () {
             ExtensionLoader.getUserExtensionPath = realGetUserExtensionPath;
             ExtensionLoader.loadExtension = realLoadExtension;
-            var promise = SpecRunnerUtils.deletePath(mockGetUserExtensionPath(), true);
-            waitsForDone(promise, "Mock Extension Removal", 2000);
+            runs(function () {
+                var promise = SpecRunnerUtils.deletePath(mockGetUserExtensionPath(), true);
+                waitsForDone(promise, "Mock Extension Removal", 2000);
+            });
         });
 
         it("extensions should install and load", function () {

--- a/test/spec/FindInFiles-test.js
+++ b/test/spec/FindInFiles-test.js
@@ -885,7 +885,9 @@ define(function (require, exports, module) {
 
             afterEach(function () {
                 FindInFiles.searchModel.off(".FindInFilesTest");
-                waitsForDone(CommandManager.execute(Commands.FILE_CLOSE_ALL, { _forceClose: true }), "close all files");
+                runs(function () {
+                    waitsForDone(CommandManager.execute(Commands.FILE_CLOSE_ALL, { _forceClose: true }), "close all files");
+                });
             });
 
             describe("when filename changes", function () {
@@ -1896,7 +1898,9 @@ define(function (require, exports, module) {
                         runs(function () {
                             expect($("#find-what").val()).toBe("Foo");
                         });
-                        waitsForDone(CommandManager.execute(Commands.FILE_CLOSE_ALL), "closing all files");
+                        runs(function () {
+                            waitsForDone(CommandManager.execute(Commands.FILE_CLOSE_ALL), "closing all files");
+                        });
                     });
 
                     it("should prepopulate the find bar with only first line of selected text", function () {
@@ -1919,7 +1923,9 @@ define(function (require, exports, module) {
                         runs(function () {
                             expect($("#find-what").val()).toBe("Foo</title>");
                         });
-                        waitsForDone(CommandManager.execute(Commands.FILE_CLOSE_ALL), "closing all files");
+                        runs(function () {
+                            waitsForDone(CommandManager.execute(Commands.FILE_CLOSE_ALL), "closing all files");
+                        });
                     });
 
                     it("should show results from the search with all checkboxes checked", function () {

--- a/test/spec/LanguageManager-test.js
+++ b/test/spec/LanguageManager-test.js
@@ -36,9 +36,11 @@ define(function (require, exports, module) {
     describe("LanguageManager", function () {
 
         beforeEach(function () {
-            waitsForDone(LanguageManager.ready, "LanguageManager ready", 10000);
+            runs(function () {
+                waitsForDone(LanguageManager.ready, "LanguageManager ready", 10000);
 
-            spyOn(console, "error");
+                spyOn(console, "error");
+            });
         });
 
         afterEach(function () {
@@ -527,9 +529,11 @@ define(function (require, exports, module) {
                         }
                     });
                 });
-                waitsForDone(writeDeferred.promise(), "old file creation");
+                runs(function () {
+                    waitsForDone(writeDeferred.promise(), "old file creation");
 
-                SpecRunnerUtils.loadProjectInTestWindow(tempDir);
+                    SpecRunnerUtils.loadProjectInTestWindow(tempDir);
+                });
 
                 runs(function () {
                     waitsForDone(DocumentManager.getDocumentForPath(oldFilename).done(function (_doc) {
@@ -561,8 +565,9 @@ define(function (require, exports, module) {
                             renameDeferred.resolve();
                         }
                     });
+
+                    waitsForDone(renameDeferred.promise(), "old file rename");
                 });
-                waitsForDone(renameDeferred.promise(), "old file rename");
 
                 runs(function () {
                     html = LanguageManager.getLanguage("html");
@@ -581,8 +586,10 @@ define(function (require, exports, module) {
                     doc.releaseRef();
                 });
 
-                SpecRunnerUtils.closeTestWindow();
-                SpecRunnerUtils.removeTempDirectory();
+                runs(function () {
+                    SpecRunnerUtils.closeTestWindow();
+                    SpecRunnerUtils.removeTempDirectory();
+                });
             });
 
             it("should update the document's language when a language is added", function () {

--- a/test/spec/PreferencesBase-test.js
+++ b/test/spec/PreferencesBase-test.js
@@ -1450,7 +1450,9 @@ define(function (require, exports, module) {
                     originalText = text;
                     deferred.resolve();
                 });
-                waitsForDone(deferred.promise());
+                runs(function () {
+                    waitsForDone(deferred.promise());
+                });
             });
 
             beforeEach(function () {
@@ -1466,7 +1468,9 @@ define(function (require, exports, module) {
                         deferred.resolve();
                     }
                 });
-                waitsForDone(deferred.promise());
+                runs(function () {
+                    waitsForDone(deferred.promise());
+                });
 
                 var deleted = false;
                 runs(function () {
@@ -1483,7 +1487,9 @@ define(function (require, exports, module) {
                 var filestorage = new PreferencesBase.FileStorage(settingsFile.fullPath);
                 var pm = new PreferencesBase.PreferencesSystem();
                 var projectScope = new PreferencesBase.Scope(filestorage);
-                waitsForDone(pm.addScope("project", projectScope));
+                runs(function () {
+                    waitsForDone(pm.addScope("project", projectScope));
+                });
                 runs(function () {
                     projectScope.addLayer(new PreferencesBase.PathLayer("/"));
                     expect(pm.get("spaceUnits")).toBe(9);
@@ -1499,7 +1505,9 @@ define(function (require, exports, module) {
                 var filestorage = new PreferencesBase.FileStorage(settingsFile.fullPath);
                 var pm = new PreferencesBase.PreferencesSystem();
                 var projectScope = new PreferencesBase.Scope(filestorage);
-                waitsForDone(pm.addScope("project", projectScope));
+                runs(function () {
+                    waitsForDone(pm.addScope("project", projectScope));
+                });
                 runs(function () {
                     projectScope.addLayer(new PreferencesBase.PathLayer("/"));
                     pm.definePreference("spaceUnits", "number", 3, {
@@ -1516,7 +1524,9 @@ define(function (require, exports, module) {
                 var filestorage = new PreferencesBase.FileStorage(settingsFile.fullPath);
                 var pm = new PreferencesBase.PreferencesSystem();
                 var projectScope = new PreferencesBase.Scope(filestorage);
-                waitsForDone(pm.addScope("project", projectScope));
+                runs(function () {
+                    waitsForDone(pm.addScope("project", projectScope));
+                });
                 runs(function () {
                     var memstorage = new PreferencesBase.MemoryStorage();
                     pm.addScope("session", new PreferencesBase.Scope(memstorage));
@@ -1541,7 +1551,9 @@ define(function (require, exports, module) {
                 var filestorage = new PreferencesBase.FileStorage(newSettingsFile.fullPath, true);
                 var pm = new PreferencesBase.PreferencesSystem();
                 var newScope = new PreferencesBase.Scope(filestorage);
-                waitsForDone(pm.addScope("new", newScope), "adding scope");
+                runs(function () {
+                    waitsForDone(pm.addScope("new", newScope), "adding scope");
+                });
                 runs(function () {
                     pm.set("unicorn-filled", true, {
                         location: {
@@ -1574,9 +1586,11 @@ define(function (require, exports, module) {
                 var newScope = new PreferencesBase.Scope(filestorage);
                 newScope.addLayer(new PreferencesBase.PathLayer("/"));
                 var changes = [];
-                waitsForDone(pm.addScope("new", newScope), "adding scope");
-                pm.on("change", function (change, data) {
-                    changes.push(data);
+                runs(function () {
+                    waitsForDone(pm.addScope("new", newScope), "adding scope");
+                    pm.on("change", function (change, data) {
+                        changes.push(data);
+                    });
                 });
                 runs(function () {
                     expect(pm.get("spaceUnits")).toBeUndefined();
@@ -1597,7 +1611,9 @@ define(function (require, exports, module) {
                 var filestorage = new PreferencesBase.FileStorage(emptySettingsFile.fullPath),
                     promise = filestorage.load();
 
-                waitsForDone(promise, "loading empty JSON file");
+                runs(function () {
+                    waitsForDone(promise, "loading empty JSON file");
+                });
                 runs(function () {
                     promise.then(function (data) {
                         expect(data).toEqual({});

--- a/test/spec/PreferencesManager-test.js
+++ b/test/spec/PreferencesManager-test.js
@@ -54,7 +54,9 @@ define(function (require, exports, module) {
         it("should find preferences in the project", function () {
             var projectWithoutSettings = SpecRunnerUtils.getTestPath("/spec/WorkingSetView-test-files"),
                 FileViewController = testWindow.brackets.test.FileViewController;
-            waitsForDone(SpecRunnerUtils.openProjectFiles(".brackets.json"));
+            runs(function () {
+                waitsForDone(SpecRunnerUtils.openProjectFiles(".brackets.json"));
+            });
 
             runs(function () {
                 expect(PreferencesManager.get("spaceUnits")).toBe(9);

--- a/test/spec/ProjectModel-test.js
+++ b/test/spec/ProjectModel-test.js
@@ -364,7 +364,9 @@ define(function (require, exports, module) {
                     changeFired = true;
                 });
 
-                waitsForDone(model.setProjectRoot(root));
+                runs(function () {
+                    waitsForDone(model.setProjectRoot(root));
+                });
 
                 runs(function () {
                     expect(vm._treeData.toJS()).toEqual({
@@ -571,7 +573,9 @@ define(function (require, exports, module) {
                             isFile: false
                         }
                     ]).promise());
-                    waitsForDone(model.setDirectoryOpen("/foo/subdir2/", true));
+                    runs(function () {
+                        waitsForDone(model.setDirectoryOpen("/foo/subdir2/", true));
+                    });
                     runs(function () {
                         expect(model._getDirectoryContents).toHaveBeenCalledWith("/foo/subdir2/");
                         expect(vm._treeData.get("subdir2").toJS()).toEqual({
@@ -588,7 +592,9 @@ define(function (require, exports, module) {
 
                 it("shouldn't load a directory that will be closed", function () {
                     spyOn(model, "_getDirectoryContents").andReturn(new $.Deferred().resolve([]).promise());
-                    waitsForDone(model.setDirectoryOpen("/foo/subdir2", false));
+                    runs(function () {
+                        waitsForDone(model.setDirectoryOpen("/foo/subdir2", false));
+                    });
                     runs(function () {
                         expect(vm._treeData.get("subdir2").toJS()).toEqual({
                             children: null
@@ -640,7 +646,9 @@ define(function (require, exports, module) {
 
             describe("startRename and friends", function () {
                 it("should resolve if there's no path or context", function () {
-                    waitsForDone(model.startRename());
+                    runs(function () {
+                        waitsForDone(model.startRename());
+                    });
                 });
 
                 it("should set the rename flag on a file", function () {
@@ -794,10 +802,13 @@ define(function (require, exports, module) {
 
                 it("fails for invalid filenames", function () {
                     model.setContext("/foo/afile.js");
-                    var promise = model.startRename();
-                    model.setRenameValue("com1");
-                    model.performRename();
-                    waitsForFail(promise);
+                    var promise;
+                    runs(function () {
+                        promise = model.startRename();
+                        model.setRenameValue("com1");
+                        model.performRename();
+                        waitsForFail(promise);
+                    });
                     runs(function () {
                         promise.fail(function (errorInfo) {
                             expect(errorInfo.type).toBe(ProjectModel.ERROR_INVALID_FILENAME);
@@ -942,10 +953,12 @@ define(function (require, exports, module) {
                 });
 
                 it("triggers a failure for an invalid filename", function () {
-                    var promise = model.startCreating("/foo/", "Untitled");
-                    model.setRenameValue("com1");
-                    model.performRename();
-                    waitsForFail(promise);
+                    runs(function () {
+                        var promise = model.startCreating("/foo/", "Untitled");
+                        model.setRenameValue("com1");
+                        model.performRename();
+                        waitsForFail(promise);
+                    });
                     runs(function () {
                         expect(creationErrors).toEqual([
                             {
@@ -1118,7 +1131,9 @@ define(function (require, exports, module) {
             });
 
             it("should reopen previously closed nodes", function () {
-                waitsForDone(model.reopenNodes(data.nodesByDepth));
+                runs(function () {
+                    waitsForDone(model.reopenNodes(data.nodesByDepth));
+                });
                 runs(function () {
                     var subdir1 = vm._treeData.get("subdir1");
                     expect(subdir1.get("open")).toBe(true);
@@ -1129,7 +1144,9 @@ define(function (require, exports, module) {
 
             it("should refresh the whole tree", function () {
                 var oldTree;
-                waitsForDone(model.reopenNodes(data.nodesByDepth));
+                runs(function () {
+                    waitsForDone(model.reopenNodes(data.nodesByDepth));
+                });
                 runs(function () {
                     model.setSelected("/foo/subdir1/subsubdir/interior.txt");
                     model.setContext("/foo/subdir3/higher.txt");
@@ -1167,7 +1184,9 @@ define(function (require, exports, module) {
             });
 
             it("should open a closed path via setDirectoryOpen", function () {
-                waitsForDone(model.setDirectoryOpen("/foo/subdir1/subsubdir/", true));
+                runs(function () {
+                    waitsForDone(model.setDirectoryOpen("/foo/subdir1/subsubdir/", true));
+                });
                 runs(function () {
                     expect(vm._treeData.getIn(["subdir1", "open"])).toBe(true);
                     expect(vm._treeData.getIn(["subdir1", "children", "subsubdir", "open"])).toBe(true);
@@ -1176,14 +1195,18 @@ define(function (require, exports, module) {
             });
 
             it("should not have a problem at the root", function () {
-                waitsForDone(model.setDirectoryOpen("/foo/"));
+                runs(function () {
+                    waitsForDone(model.setDirectoryOpen("/foo/"));
+                });
                 runs(function () {
                     expect(vm._treeData.get("open")).toBeUndefined();
                 });
             });
 
             it("should do nothing for a path that is outside of the project", function () {
-                waitsForDone(model.showInTree("/bar/baz.js"));
+                runs(function () {
+                    waitsForDone(model.showInTree("/bar/baz.js"));
+                });
                 runs(function () {
                     expect(vm._treeData.get("baz.js")).toBeUndefined();
                     expect(model._selections.selected).toBeUndefined();
@@ -1192,7 +1215,9 @@ define(function (require, exports, module) {
 
             it("should do nothing for a path that is outside of the project on Windows", function () {
                 model.projectRoot = "c:/foo/";
-                waitsForDone(model.showInTree("c:/bar/baz.js"));
+                runs(function () {
+                    waitsForDone(model.showInTree("c:/bar/baz.js"));
+                });
                 runs(function () {
                     expect(vm._treeData.get("baz.js")).toBeUndefined();
                     expect(model._selections.selected).toBeUndefined();
@@ -1200,14 +1225,18 @@ define(function (require, exports, module) {
             });
 
             it("should select a file at the root", function () {
-                waitsForDone(model.showInTree("/foo/toplevel.txt"));
+                runs(function () {
+                    waitsForDone(model.showInTree("/foo/toplevel.txt"));
+                });
                 runs(function () {
                     expect(vm._treeData.getIn(["toplevel.txt", "selected"])).toBe(true);
                 });
             });
 
             it("should open a subdirectory", function () {
-                waitsForDone(model.showInTree("/foo/subdir1/"));
+                runs(function () {
+                    waitsForDone(model.showInTree("/foo/subdir1/"));
+                });
                 runs(function () {
                     expect(vm._treeData.getIn(["subdir1", "open"])).toBe(true);
                     expect(vm._treeData.getIn(["subdir1", "children", "subsubdir"])).toBeDefined();
@@ -1217,7 +1246,9 @@ define(function (require, exports, module) {
 
             it("should open a subdirectory and select a file", function () {
                 model.setFocused(false);
-                waitsForDone(model.showInTree("/foo/subdir1/subsubdir/interior.txt"));
+                runs(function () {
+                    waitsForDone(model.showInTree("/foo/subdir1/subsubdir/interior.txt"));
+                });
                 runs(function () {
                     expect(vm._treeData.getIn(["subdir1", "open"])).toBe(true);
                     expect(vm._treeData.getIn(["subdir1", "children", "subsubdir", "open"])).toBe(true);
@@ -1239,7 +1270,9 @@ define(function (require, exports, module) {
             });
 
             it("should open all of the sibling directories", function () {
-                waitsForDone(model.setDirectoryOpen("/foo/subdir4/", true));
+                runs(function () {
+                    waitsForDone(model.setDirectoryOpen("/foo/subdir4/", true));
+                });
                 runs(function () {
                     waitsForDone(model.toggleSubdirectories("/foo/subdir4/", true));
                 });
@@ -1251,7 +1284,9 @@ define(function (require, exports, module) {
             });
 
             it("should close all of the sibling directories", function () {
-                waitsForDone(model.setDirectoryOpen("/foo/subdir4/", true));
+                runs(function () {
+                    waitsForDone(model.setDirectoryOpen("/foo/subdir4/", true));
+                });
                 runs(function () {
                     waitsForDone(model.toggleSubdirectories("/foo/subdir4/", true));
                 });
@@ -1277,7 +1312,9 @@ define(function (require, exports, module) {
             });
 
             it("should close the directory and its children", function () {
-                waitsForDone(model.setDirectoryOpen("/foo/subdir4/", true));
+                runs(function () {
+                    waitsForDone(model.setDirectoryOpen("/foo/subdir4/", true));
+                });
                 runs(function () {
                     waitsForDone(model.toggleSubdirectories("/foo/subdir4/", true));
                 });

--- a/test/spec/SpecRunnerUtils.js
+++ b/test/spec/SpecRunnerUtils.js
@@ -249,9 +249,9 @@ define(function (require, exports, module) {
                     deferred.resolve();
                 }
             });
-        });
 
-        waitsForDone(deferred, "Create temp directory", 500);
+            waitsForDone(deferred.promise(), "Create temp directory", 500);
+        });
     }
 
     function _resetPermissionsOnSpecialTempFolders() {

--- a/test/spec/ThemeManager-test.js
+++ b/test/spec/ThemeManager-test.js
@@ -21,7 +21,7 @@
  *
  */
 
-/*global describe, it, expect, waitsForDone */
+/*global describe, it, expect, waitsForDone, runs */
 
 define(function (require, exports, module) {
     "use strict";
@@ -68,7 +68,9 @@ define(function (require, exports, module) {
                     expect(superTrim(themeScrollbars.content)).toEqual("span{}");
                 });
 
-                waitsForDone(promise, "theme with scrollbar and other css", 5000);
+                runs(function () {
+                    waitsForDone(promise, "theme with scrollbar and other css", 5000);
+                });
             });
 
             it("should extract scrollbars from a theme with only scrollbars", function () {
@@ -80,7 +82,9 @@ define(function (require, exports, module) {
                     expect(superTrim(themeScrollbars.content)).toEqual("");
                 });
 
-                waitsForDone(promise, "theme with only scrollbars", 5000);
+                runs(function () {
+                    waitsForDone(promise, "theme with only scrollbars", 5000);
+                });
             });
 
             it("should be fine with an empty theme", function () {
@@ -91,7 +95,9 @@ define(function (require, exports, module) {
                     expect(superTrim(themeScrollbars.content)).toEqual("");
                 });
 
-                waitsForDone(promise, "empty theme", 5000);
+                runs(function () {
+                    waitsForDone(promise, "empty theme", 5000);
+                });
             });
         });
 
@@ -103,7 +109,9 @@ define(function (require, exports, module) {
                     expect(theme.displayName).toEqual("Scrollbars");
                 });
 
-                waitsForDone(promise, "theme file", 5000);
+                runs(function () {
+                    waitsForDone(promise, "theme file", 5000);
+                });
             });
         });
     });


### PR DESCRIPTION
In SpecRunnerUtils there are a couple of comments indicating these functions should called from inside a `runs` one.
I thought that `waitsFor` should be called after `runs` and not from inside, but I don't think this hurt.