### PR TITLE
Fix DocumentCommandHandlers test on macOS

### DIFF
--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -1157,8 +1157,13 @@ define(function (require, exports, module) {
                     expect(doc.isDirty).toBe(true);
 
                     // verify dot in titlebar
-                    expect(testWindow.document.title).toBe("• test.js (DocumentCommandHandlers-test-files) " + WINDOW_TITLE_DOT + " " + brackets.config.app_title);
-
+                    var title;
+                    if (brackets.platform === "mac") {
+                        title = "test.js (DocumentCommandHandlers-test-files)";
+                    } else {
+                        title = "• test.js (DocumentCommandHandlers-test-files)";
+                    }
+                    expect(testWindow.document.title).toBe(title + " " + WINDOW_TITLE_DOT + " " + brackets.config.app_title);
                 });
             });
 


### PR DESCRIPTION
On macOS it is used and electron API to set when a document is edited.