### PR TITLE
ESLint: use the glob configuration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,4 @@
 module.exports = {
-    "parser": "typescript-eslint-parser",
-    "parserOptions": {
-        "sourceType": "script"
-    },
     "rules": {
         // the rules below should be sorted in a same way they are sorted on http://eslint.org/docs/rules page
         // http://eslint.org/docs/rules/#possible-errors
@@ -86,5 +82,27 @@ module.exports = {
         "Uint32Array": false,
         "WebSocket": false,
         "XMLHttpRequest": false
-    }
+    },
+    "overrides": [
+      {
+        "files": [ "**/*.ts" ],
+        "excludedFiles": "**/*.js",
+        "parser": "typescript-eslint-parser",
+        "parserOptions": {
+            "sourceType": "module"
+        },
+        "rules": {
+          "no-undef": "off"
+        }
+      },
+      {
+        "files": [
+          "Gruntfile.js",
+          "tasks/**/*.js"
+        ],
+        "parserOptions": {
+          "ecmaVersion": 6
+        }
+      }
+    ]
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -237,21 +237,28 @@ module.exports = function (grunt) {
                 }]
             }
         },
-        meta : {
-            src   : [
+        meta: {
+            app: [
+                'app/**/*.js',
+                'app/**/*.ts'
+            ],
+            src: [
                 'src/**/*.js',
+                'src/**/*.ts',
                 '!src/thirdparty/**',
                 '!src/widgets/bootstrap-*.js',
                 '!src/extensions/**/unittest-files/**/*.js',
                 '!src/extensions/**/thirdparty/**/*.js',
+                '!src/extensions/default/quadre-eslint/**',
                 '!src/extensions/dev/**',
                 '!src/extensions/disabled/**',
                 '!**/node_modules/**/*.js',
                 '!src/**/*-min.js',
                 '!src/**/*.min.js'
             ],
-            test : [
+            test: [
                 'test/**/*.js',
+                'test/**/*.ts',
                 '!test/perf/*-files/**/*.js',
                 '!test/spec/*-files/**/*.js',
                 '!test/spec/*-known-goods/**/*.js',
@@ -263,10 +270,11 @@ module.exports = function (grunt) {
             ],
             grunt: [
                 'Gruntfile.js',
-                'tasks/**/*.js'
+                'tasks/**/*.js',
+                'tasks/**/*.ts'
             ],
             /* specs that can run in phantom.js */
-            specs : [
+            specs: [
                 'test/spec/CommandManager-test.js',
                 //'test/spec/LanguageManager-test.js',
                 //'test/spec/PreferencesManager-test.js',
@@ -330,6 +338,7 @@ module.exports = function (grunt) {
         },
         eslint: {
             grunt:  '<%= meta.grunt %>',
+            app:    '<%= meta.app %>',
             src:    '<%= meta.src %>',
             test:   '<%= meta.test %>',
             options: {

--- a/app/appshell/app-menu.ts
+++ b/app/appshell/app-menu.ts
@@ -152,6 +152,7 @@ function _fixBracketsKeyboardShortcut(shortcut: string): string {
     shortcut = shortcut.replace(/\u2193/g, "Down");
     shortcut = shortcut.replace(/\u2212/g, "-");
 
+    // eslint-disable-next-line no-control-regex
     if (!shortcut.match(/^[\x00-\x7F]+$/)) {
         console.error("Non ASCII keyboard shortcut used: " + shortcut);
         return "";

--- a/app/main.ts
+++ b/app/main.ts
@@ -97,6 +97,7 @@ ipcMain.on("brackets-app-ready", () => {
 app.on("ready", function () {
     const win = openMainBracketsWindow();
     try {
+        // eslint-disable-next-line no-new
         new AutoUpdater(win);
     } catch (err) {
         log.error(err.stack);

--- a/src/command/Menus.js
+++ b/src/command/Menus.js
@@ -471,7 +471,7 @@ define(function (require, exports, module) {
             // Targeting parent to get the menu item <a> and the <li> that contains it
             $(_getHTMLMenuItem(menuItemID)).parent().remove();
         } else {
-            const winId = electron.remote.getCurrentWindow().id;
+            var winId = electron.remote.getCurrentWindow().id;
             brackets.app.removeMenuItem(winId, commandID, function (err) {
                 if (err) {
                     console.error("removeMenuItem() -- command not found: " + commandID + " (error: " + err + ")");
@@ -518,7 +518,7 @@ define(function (require, exports, module) {
                 return;
             }
         } else {
-            const winId = electron.remote.getCurrentWindow().id;
+            var winId = electron.remote.getCurrentWindow().id;
             brackets.app.removeMenuItem(winId, menuItem.dividerId, function (err) {
                 if (err) {
                     console.error("removeMenuDivider() -- divider not found: %s (error: %s)", menuItemID, err);
@@ -646,7 +646,7 @@ define(function (require, exports, module) {
                 relativeID = relativeID.sectionMarker;
             }
 
-            const winId = electron.remote.getCurrentWindow().id;
+            var winId = electron.remote.getCurrentWindow().id;
             brackets.app.addMenuItem(winId, this.id, name, commandID, bindingStr, displayStr, position, relativeID, function (err) {
                 switch (err) {
                 case NO_ERROR:
@@ -780,7 +780,7 @@ define(function (require, exports, module) {
     MenuItem.prototype._checkedChanged = function () {
         var checked = !!this._command.getChecked();
         if (this.isNative) {
-            const winId = electron.remote.getCurrentWindow().id;
+            var winId = electron.remote.getCurrentWindow().id;
             var enabled = !!this._command.getEnabled();
             brackets.app.setMenuItemState(winId, this._command.getID(), enabled, checked, function (err) {
                 if (err) {
@@ -797,7 +797,7 @@ define(function (require, exports, module) {
      */
     MenuItem.prototype._enabledChanged = function () {
         if (this.isNative) {
-            const winId = electron.remote.getCurrentWindow().id;
+            var winId = electron.remote.getCurrentWindow().id;
             var enabled = !!this._command.getEnabled();
             var checked = !!this._command.getChecked();
             brackets.app.setMenuItemState(winId, this._command.getID(), enabled, checked, function (err) {
@@ -815,7 +815,7 @@ define(function (require, exports, module) {
      */
     MenuItem.prototype._nameChanged = function () {
         if (this.isNative) {
-            const winId = electron.remote.getCurrentWindow().id;
+            var winId = electron.remote.getCurrentWindow().id;
             brackets.app.setMenuTitle(winId, this._command.getID(), this._command.getName(), function (err) {
                 if (err) {
                     console.log("Error setting menu title: " + err);
@@ -832,7 +832,7 @@ define(function (require, exports, module) {
      */
     MenuItem.prototype._keyBindingAdded = function (event, keyBinding) {
         if (this.isNative) {
-            const winId = electron.remote.getCurrentWindow().id;
+            var winId = electron.remote.getCurrentWindow().id;
             var shortcutKey = keyBinding.displayKey || keyBinding.key;
             brackets.app.setMenuItemShortcut(winId, this._command.getID(), shortcutKey, KeyBindingManager.formatKeyDescriptor(shortcutKey), function (err) {
                 if (err) {
@@ -850,7 +850,7 @@ define(function (require, exports, module) {
      */
     MenuItem.prototype._keyBindingRemoved = function (event, keyBinding) {
         if (this.isNative) {
-            const winId = electron.remote.getCurrentWindow().id;
+            var winId = electron.remote.getCurrentWindow().id;
             brackets.app.setMenuItemShortcut(winId, this._command.getID(), "", "", function (err) {
                 if (err) {
                     console.error("Error setting menu item shortcut: " + err);
@@ -910,7 +910,7 @@ define(function (require, exports, module) {
         menuMap[id] = menu;
 
         if (!_isHTMLMenu(id)) {
-            const winId = electron.remote.getCurrentWindow().id;
+            var winId = electron.remote.getCurrentWindow().id;
             brackets.app.addMenu(winId, name, id, position, relativeID, function (err) {
                 switch (err) {
                 case NO_ERROR:
@@ -991,7 +991,7 @@ define(function (require, exports, module) {
         if (_isHTMLMenu(id)) {
             $(_getHTMLMenu(id)).remove();
         } else {
-            const winId = electron.remote.getCurrentWindow().id;
+            var winId = electron.remote.getCurrentWindow().id;
             brackets.app.removeMenu(winId, id, function (err) {
                 if (err) {
                     console.error("removeMenu() -- id not found: " + id + " (error: " + err + ")");

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1677,7 +1677,7 @@ define(function (require, exports, module) {
                     href = href.substr(0, fragment);
                 }
 
-                setTimeout(() => electron.remote.require("./main").restart(href), 500);
+                setTimeout(function () { electron.remote.require("./main").restart(href); }, 500);
             });
         }).fail(function () {
             _isReloading = false;

--- a/src/extensibility/Package.js
+++ b/src/extensibility/Package.js
@@ -579,7 +579,7 @@ define(function (require, exports, module) {
                         _nodeConnectionDeferred.resolve();
                     },
                     function () { // Failed to connect
-                        console.error(`ExtensionManagerDomain failed to load: ${arguments}`);
+                        console.error('ExtensionManagerDomain failed to load: ' + arguments);
                         _nodeConnectionDeferred.reject();
                     }
                 );

--- a/src/extensions/default/HealthData/HealthDataManager.js
+++ b/src/extensions/default/HealthData/HealthDataManager.js
@@ -100,7 +100,7 @@ define(function (require, exports, module) {
             var urls = brackets.config.healthDataServerURLs,
                 data = JSON.stringify(healthData);
 
-            urls.forEach(url => {
+            urls.forEach(function (url) {
 
                 $.ajax({
                     url: url,

--- a/src/utils/ShellAPI.ts
+++ b/src/utils/ShellAPI.ts
@@ -1,60 +1,55 @@
-// define(function (require, exports, module) {
-    "use strict";
+// Load dependent modules
+import AppInit        = require("utils/AppInit");
+import CommandManager = require("command/CommandManager");
+import Commands       = require("command/Commands");
 
-    // Load dependent modules
-    import AppInit        = require("utils/AppInit");
-    import CommandManager = require("command/CommandManager");
-    import Commands       = require("command/Commands");
+let appReady = false; // Set to true after app is fully initialized
+let appShortcuts: { [shortcut: string]: string } = {};
 
-    let appReady = false; // Set to true after app is fully initialized
-    let appShortcuts: { [shortcut: string]: string } = {};
+electron.ipcRenderer.on("updateShortcuts", function (evt: any, data: string) {
+    appShortcuts = JSON.parse(data);
+});
 
-    electron.ipcRenderer.on("updateShortcuts", function (evt: any, data: string) {
-        appShortcuts = JSON.parse(data);
-    });
-
-    function executeCommand(eventName: string) {
-        // Temporary fix for #2616 - don't execute the command if a modal dialog is open.
-        // This should really be fixed with proper menu enabling.
-        if ($(".modal.instance").length || !appReady) {
-            // Another hack to fix issue #3219 so that all test windows are closed
-            // as before the fix for #3152 has been introduced. isBracketsTestWindow
-            // property is explicitly set in createTestWindowAndRun() in SpecRunnerUtils.js.
-            if ((window as any).isBracketsTestWindow) {
-                return false;
-            }
-            // Return false for all commands except file.close_window command for
-            // which we have to return true (issue #3152).
-            return (eventName === Commands.FILE_CLOSE_WINDOW);
+function executeCommand(eventName: string) {
+    // Temporary fix for #2616 - don't execute the command if a modal dialog is open.
+    // This should really be fixed with proper menu enabling.
+    if ($(".modal.instance").length || !appReady) {
+        // Another hack to fix issue #3219 so that all test windows are closed
+        // as before the fix for #3152 has been introduced. isBracketsTestWindow
+        // property is explicitly set in createTestWindowAndRun() in SpecRunnerUtils.js.
+        if ((window as any).isBracketsTestWindow) {
+            return false;
         }
-
-        const promise = CommandManager.execute(eventName);
-        return (promise && promise.state() === "rejected") ? false : true;
+        // Return false for all commands except file.close_window command for
+        // which we have to return true (issue #3152).
+        return (eventName === Commands.FILE_CLOSE_WINDOW);
     }
 
-    (window as any).triggerKeyboardShortcut = (shortcut: string) => {
-        const normalized = shortcut.replace(/-/g, "+");
-        if (appShortcuts[normalized]) {
-            return executeCommand(appShortcuts[normalized]);
-        }
-        return null;
-    };
+    const promise = CommandManager.execute(eventName);
+    return (promise && promise.state() === "rejected") ? false : true;
+}
 
-    electron.ipcRenderer.on("executeCommand", function (evt: any, eventName: string) {
-        return executeCommand(eventName);
-    });
+(window as any).triggerKeyboardShortcut = (shortcut: string) => {
+    const normalized = shortcut.replace(/-/g, "+");
+    if (appShortcuts[normalized]) {
+        return executeCommand(appShortcuts[normalized]);
+    }
+    return null;
+};
 
-    electron.ipcRenderer.on("console-msg", function (evt: any, method: string, ...args: string[]) {
-        (console as any)[method]("[shell]", ...args);
-    });
+electron.ipcRenderer.on("executeCommand", function (evt: any, eventName: string) {
+    return executeCommand(eventName);
+});
 
-    electron.ipcRenderer.on("notify", function (evt: any, title: string, message: string) {
-        window.alert(`${title}\n\n${message}`);
-    });
+electron.ipcRenderer.on("console-msg", function (evt: any, method: string, ...args: string[]) {
+    (console as any)[method]("[shell]", ...args);
+});
 
-    AppInit.appReady(function () {
-        electron.ipcRenderer.send("brackets-app-ready");
-        appReady = true;
-    });
+electron.ipcRenderer.on("notify", function (evt: any, title: string, message: string) {
+    window.alert(`${title}\n\n${message}`);
+});
 
-// });
+AppInit.appReady(function () {
+    electron.ipcRenderer.send("brackets-app-ready");
+    appReady = true;
+});


### PR DESCRIPTION
So it is possible to configure multiple parser:
the default one for *.js files and typescript-eslint-parser for *.ts files.

Some changes inside src folder are because the default ecmaVersion of ESLint is still 5.