### PR TITLE
MSI installer: do not error out on warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,9 @@
         "msi"
       ]
     },
+    "msi": {
+      "warningsAsErrors": false
+    },
     "mac": {
       "category": "public.app-category.developer-tools"
     },

--- a/src/config.json
+++ b/src/config.json
@@ -57,6 +57,9 @@
                 "msi"
             ]
         },
+        "msi": {
+            "warningsAsErrors": false
+        },
         "mac": {
             "category": "public.app-category.developer-tools"
         },


### PR DESCRIPTION
Try to fix `Error: Exit code: 1147. Command failed: ...` I see on appveyor.
https://github.com/electron-userland/electron-builder/issues/2280