### PR TITLE
ESLint: enable no-unused-vars on js files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,7 +63,7 @@ module.exports = {
         "no-shadow-restricted-names": "error",
         "no-shadow": "warn",
         "no-undef": "error",
-        "no-unused-vars": ["warn", {"vars": "all", "args": "none"}],
+        "no-unused-vars": ["error", {"vars": "all", "args": "none"}],
         "no-use-before-define": "off",
         // http://eslint.org/docs/rules/#nodejs-and-commonjs
         "no-new-require": "error",
@@ -174,6 +174,9 @@ module.exports = {
         {
             "files": [
                 "test/**",
+                "src/extensions/default/**/unittests.js",
+                "src/extensions/default/**/unittests.disabled.js",
+                "src/extensibility/node/spec/*.js"
             ],
             "env": {
                 "jasmine": true,

--- a/src/LiveDevelopment/Agents/RemoteFunctions.js
+++ b/src/LiveDevelopment/Agents/RemoteFunctions.js
@@ -25,6 +25,7 @@
 /*jslint forin: true */
 /*global Node, MessageEvent */
 /*theseus instrument: false */
+/*exported RemoteFunctions*/
 
 /**
  * RemoteFunctions define the functions to be executed in the browser. This
@@ -384,8 +385,6 @@ function RemoteFunctions(config, remoteWSPort) {
                 }
             };
 
-            var mainBoxStyles = config.remoteHighlight.stylesToSet;
-
             var paddingVisualisations = [
               drawPaddingRect("top"),
               drawPaddingRect("right"),
@@ -430,8 +429,6 @@ function RemoteFunctions(config, remoteWSPort) {
             );
 
             highlight.className = HIGHLIGHT_CLASSNAME;
-
-            var offset = _screenOffset(element);
 
             var el = element,
             offsetLeft = 0,
@@ -557,6 +554,7 @@ function RemoteFunctions(config, remoteWSPort) {
         }
     };
 
+    // eslint-disable-next-line no-unused-vars
     var _currentEditor;
     function _toggleEditor(element) {
         _currentEditor = new Editor(element);
@@ -1031,9 +1029,7 @@ function RemoteFunctions(config, remoteWSPort) {
     var _ws = null;
 
     function onDocumentClick(event) {
-        var element = event.target,
-            currentDataId,
-            newDataId;
+        var element = event.target;
 
         if (_ws && element && element.hasAttribute("data-brackets-id")) {
             _ws.send(JSON.stringify({

--- a/src/LiveDevelopment/LiveDevelopment.js
+++ b/src/LiveDevelopment/LiveDevelopment.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global open */
-
 /**
  * LiveDevelopment manages the Inspector, all Agents, and the active LiveDocument
  *

--- a/src/LiveDevelopment/MultiBrowserImpl/language/HTMLSimpleDOM.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/language/HTMLSimpleDOM.js
@@ -267,7 +267,11 @@ define(function (require, exports, module) {
      */
     Builder.prototype.build = function (strict, markCache) {
         var self = this;
-        var token, lastClosedTag, lastTextNode, lastIndex = 0;
+        var token,
+            lastClosedTag,
+            lastTextNode,
+            // eslint-disable-next-line no-unused-vars
+            lastIndex = 0;
         var stack = this.stack;
         var attributeName = null;
         var nodeMap = {};

--- a/src/LiveDevelopment/MultiBrowserImpl/launchers/node/LauncherDomain.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/launchers/node/LauncherDomain.js
@@ -33,6 +33,7 @@ var open = require("opn");
  * The Brackets domain manager for registering node extensions.
  * @type {?DomainManager}
  */
+// eslint-disable-next-line no-unused-vars
 var _domainManager;
 
 /**

--- a/src/LiveDevelopment/MultiBrowserImpl/protocol/remote/DocumentObserver.js
+++ b/src/LiveDevelopment/MultiBrowserImpl/protocol/remote/DocumentObserver.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global setInterval, clearInterval */
-
 (function (global) {
     "use strict";
 
@@ -139,12 +137,12 @@
                 //        http://stackoverflow.com/questions/11425209/are-dom-mutation-observers-slower-than-dom-mutation-events
                 //
                 // TODO: This is just a temporary 'cross-browser' solution, it needs optimization.
-                var loadInterval = setInterval(function () {
+                var loadInterval = window.setInterval(function () {
                     var i;
                     for (i = 0; i < window.document.styleSheets.length; i++) {
                         if (window.document.styleSheets[i].href === href) {
                             //clear interval
-                            clearInterval(loadInterval);
+                            window.clearInterval(loadInterval);
                             // notify stylesheets added
                             self.notifyStylesheetAdded(href);
                             break;

--- a/src/brackets.js
+++ b/src/brackets.js
@@ -76,6 +76,7 @@ define(function (require, exports, module) {
         DefaultDialogs      = require("widgets/DefaultDialogs"),
         ExtensionLoader     = require("utils/ExtensionLoader"),
         Async               = require("utils/Async"),
+        // eslint-disable-next-line no-unused-vars
         UpdateNotification  = require("utils/UpdateNotification"),
         UrlParams           = require("utils/UrlParams").UrlParams,
         PreferencesManager  = require("preferences/PreferencesManager"),

--- a/src/editor/CodeHintManager.js
+++ b/src/editor/CodeHintManager.js
@@ -247,8 +247,7 @@ define(function (require, exports, module) {
         hintList         = null,
         deferredHints    = null,
         keyDownEditor    = null,
-        codeHintsEnabled = true,
-        codeHintOpened   = false;
+        codeHintsEnabled = true;
 
 
     PreferencesManager.definePreference("showCodeHints", "boolean", true, {
@@ -378,7 +377,6 @@ define(function (require, exports, module) {
         }
         hintList.close();
         hintList = null;
-        codeHintOpened = false;
         keyDownEditor = null;
         sessionProvider = null;
         sessionEditor = null;

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -2549,7 +2549,6 @@ define(function (require, exports, module) {
      * @param {string} name The name of the gutter to be unregistered.
      */
     Editor.unregisterGutter = function (name) {
-        var i, gutter;
         registeredGutters = registeredGutters.filter(function (gutter) {
             return gutter.name !== name;
         });

--- a/src/extensibility/node/spec/Installation.spec.js
+++ b/src/extensibility/node/spec/Installation.spec.js
@@ -24,7 +24,6 @@
 
 /*eslint-env node */
 /*jslint node: true */
-/*global expect, describe, it, beforeEach, afterEach */
 
 "use strict";
 

--- a/src/extensibility/node/spec/Validation.spec.js
+++ b/src/extensibility/node/spec/Validation.spec.js
@@ -24,7 +24,6 @@
 
 /*eslint-env node */
 /*jslint node: true */
-/*global expect, describe, it, afterEach */
 
 "use strict";
 

--- a/src/extensions/default/CSSAtRuleCodeHints/unittests.js
+++ b/src/extensions/default/CSSAtRuleCodeHints/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, it, xit, expect, beforeEach, afterEach */
-
 define(function (require, exports, module) {
     "use strict";
 
@@ -39,24 +37,6 @@ define(function (require, exports, module) {
 
         var testDocument, testEditor;
 
-        /*
-         * Create a mockup editor with the given content and language id.
-         *
-         * @param {string} content - content for test window
-         * @param {string} languageId
-         */
-        function setupTest(content, languageId) {
-            var mock = SpecRunnerUtils.createMockEditor(content, languageId);
-            testDocument = mock.doc;
-            testEditor = mock.editor;
-        }
-
-        function tearDownTest() {
-            SpecRunnerUtils.destroyMockEditor(testDocument);
-            testEditor = null;
-            testDocument = null;
-        }
-
         // Ask provider for hints at current cursor position; expect it to return some
         function expectHints(provider, implicitChar, returnWholeObj) {
             expect(provider.hasHints(testEditor, implicitChar)).toBe(true);
@@ -64,11 +44,6 @@ define(function (require, exports, module) {
             expect(hintsObj).toBeTruthy();
             // return just the array of hints if returnWholeObj is falsy
             return returnWholeObj ? hintsObj : hintsObj.hints;
-        }
-
-        // Ask provider for hints at current cursor position; expect it NOT to return any
-        function expectNoHints(provider, implicitChar) {
-            expect(provider.hasHints(testEditor, implicitChar)).toBe(false);
         }
 
         // compares lists to ensure they are the same
@@ -102,14 +77,6 @@ define(function (require, exports, module) {
 
         function verifyFirstEntry(hintList, expectedFirstHint) {
             expect(hintList[0]).toBe(expectedFirstHint);
-        }
-
-        // Helper function to
-        // a) ensure the hintList and the list with the available values have the same size
-        // b) ensure that all possible values are mentioned in the hintList
-        function verifyAllValues(hintList, values) {
-            expect(hintList.length).toBe(values.length);
-            expect(hintList.sort().toString()).toBe(values.sort().toString());
         }
 
         var modesToTest = ["css", "scss", "less"],

--- a/src/extensions/default/CSSCodeHints/unittests.js
+++ b/src/extensions/default/CSSCodeHints/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, it, xit, expect, beforeEach, afterEach */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/CSSPseudoSelectorHints/unittests.js
+++ b/src/extensions/default/CSSPseudoSelectorHints/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, it, xit, expect, beforeEach, afterEach */
-
 define(function (require, exports, module) {
     "use strict";
 
@@ -45,24 +43,6 @@ define(function (require, exports, module) {
 
         var testDocument, testEditor;
 
-        /*
-         * Create a mockup editor with the given content and language id.
-         *
-         * @param {string} content - content for test window
-         * @param {string} languageId
-         */
-        function setupTest(content, languageId) {
-            var mock = SpecRunnerUtils.createMockEditor(content, languageId);
-            testDocument = mock.doc;
-            testEditor = mock.editor;
-        }
-
-        function tearDownTest() {
-            SpecRunnerUtils.destroyMockEditor(testDocument);
-            testEditor = null;
-            testDocument = null;
-        }
-
         // Ask provider for hints at current cursor position; expect it to return some
         function expectHints(provider, implicitChar, returnWholeObj) {
             expect(provider.hasHints(testEditor, implicitChar)).toBe(true);
@@ -70,11 +50,6 @@ define(function (require, exports, module) {
             expect(hintsObj).toBeTruthy();
             // return just the array of hints if returnWholeObj is falsy
             return returnWholeObj ? hintsObj : hintsObj.hints;
-        }
-
-        // Ask provider for hints at current cursor position; expect it NOT to return any
-        function expectNoHints(provider, implicitChar) {
-            expect(provider.hasHints(testEditor, implicitChar)).toBe(false);
         }
 
         // compares lists to ensure they are the same
@@ -86,36 +61,8 @@ define(function (require, exports, module) {
             }
         }
 
-
-        function selectHint(provider, expectedHint, implicitChar) {
-            var hintList = expectHints(provider, implicitChar);
-            expect(hintList.indexOf(expectedHint)).not.toBe(-1);
-            return provider.insertHint(expectedHint);
-        }
-
-        // Helper function for testing cursor position
-        function fixPos(pos) {
-            if (!("sticky" in pos)) {
-                pos.sticky = null;
-            }
-            return pos;
-        }
-        function expectCursorAt(pos) {
-            var selection = testEditor.getSelection();
-            expect(fixPos(selection.start)).toEqual(fixPos(selection.end));
-            expect(fixPos(selection.start)).toEqual(fixPos(pos));
-        }
-
         function verifyFirstEntry(hintList, expectedFirstHint) {
             expect(hintList[0]).toBe(expectedFirstHint);
-        }
-
-        // Helper function to
-        // a) ensure the hintList and the list with the available values have the same size
-        // b) ensure that all possible values are mentioned in the hintList
-        function verifyAllValues(hintList, values) {
-            expect(hintList.length).toBe(values.length);
-            expect(hintList.sort().toString()).toBe(values.sort().toString());
         }
 
         var modesToTest = ["css", "scss", "less"],

--- a/src/extensions/default/CloseOthers/unittests.js
+++ b/src/extensions/default/CloseOthers/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, it, expect, beforeEach, afterEach, runs, waitsForDone, spyOn */
-
 define(function (require, exports, module) {
     "use strict";
 
@@ -31,7 +29,9 @@ define(function (require, exports, module) {
         FileUtils		= brackets.getModule("file/FileUtils"),
         CommandManager,
         Commands,
+        // eslint-disable-next-line no-unused-vars
         Dialogs,
+        // eslint-disable-next-line no-unused-vars
         EditorManager,
         DocumentManager,
         MainViewManager,
@@ -41,9 +41,11 @@ define(function (require, exports, module) {
         var extensionPath = FileUtils.getNativeModuleDirectoryPath(module),
             testPath      = extensionPath + "/unittest-files/",
             testWindow,
+            // eslint-disable-next-line no-unused-vars
             $,
             docSelectIndex,
             cmdToRun,
+            // eslint-disable-next-line no-unused-vars
             brackets;
 
         function createUntitled(count) {

--- a/src/extensions/default/CodeFolding/foldhelpers/foldgutter.js
+++ b/src/extensions/default/CodeFolding/foldhelpers/foldgutter.js
@@ -341,6 +341,7 @@ define(function (require, exports, module) {
       * @param {!Object} to the ch and line position that designates the end of the region
       */
     function onFold(cm, from, to) {
+        // eslint-disable-next-line no-unused-vars
         var state = cm.state.foldGutter;
         updateFoldInfo(cm, from.line, from.line + 1);
     }
@@ -352,6 +353,7 @@ define(function (require, exports, module) {
       * @param {!{line:number, ch:number}} to the ch and line position that designates the end of the region
       */
     function onUnFold(cm, from, to) {
+        // eslint-disable-next-line no-unused-vars
         var state = cm.state.foldGutter;
         var vp = cm.getViewport();
         delete cm._lineFolds[from.line];

--- a/src/extensions/default/CodeFolding/foldhelpers/handlebarsFold.js
+++ b/src/extensions/default/CodeFolding/foldhelpers/handlebarsFold.js
@@ -30,8 +30,8 @@
 
 define(function (require, exports, module) {
     "use strict";
-    var CodeMirror  = brackets.getModule("thirdparty/CodeMirror/lib/codemirror"),
-        _           = brackets.getModule("thirdparty/lodash"),
+
+    var _           = brackets.getModule("thirdparty/lodash"),
         StringUtils = brackets.getModule("utils/StringUtils");
 
     /**

--- a/src/extensions/default/CodeFolding/unittests.js
+++ b/src/extensions/default/CodeFolding/unittests.js
@@ -4,8 +4,6 @@
  * @date 01/08/2015 18:34
  */
 
-/*global describe, xdescribe, beforeEach, afterEach, it, expect, runs, waitsForDone, waitsFor*/
-
 define(function (require, exports, module) {
     "use strict";
     var SpecRunnerUtils = brackets.getModule("spec/SpecRunnerUtils"),
@@ -24,6 +22,7 @@ define(function (require, exports, module) {
         var testWindow,
             testEditor,
             EditorManager,
+            // eslint-disable-next-line no-unused-vars
             DocumentManager,
             CommandManager,
             PreferencesManager,

--- a/src/extensions/default/HTMLCodeHints/unittests.js
+++ b/src/extensions/default/HTMLCodeHints/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, it, xit, expect, beforeEach, afterEach */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/HealthData/unittests.disabled.js
+++ b/src/extensions/default/HealthData/unittests.disabled.js
@@ -22,7 +22,6 @@
  *
  */
 
-/*global describe, runs, beforeEach, it, afterEach, expect, waitsForDone, waitsForFail */
 /*unittests: HealthData*/
 
 define(function (require, exports, module) {

--- a/src/extensions/default/HtmlEntityCodeHints/unittests.js
+++ b/src/extensions/default/HtmlEntityCodeHints/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, it, expect, beforeEach, afterEach */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/InlineColorEditor/unittests.js
+++ b/src/extensions/default/InlineColorEditor/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, it, expect, beforeEach, afterEach, waits, runs, waitsForDone, spyOn */
-
 define(function (require, exports, module) {
     "use strict";
 
@@ -52,12 +50,6 @@ define(function (require, exports, module) {
             sel.reversed = false;
         }
         return sel;
-    }
-    function fixSels(sels) {
-        sels.forEach(function (sel) {
-            fixSel(sel);
-        });
-        return sels;
     }
 
     describe("Inline Color Editor - unit", function () {

--- a/src/extensions/default/InlineTimingFunctionEditor/unittests.js
+++ b/src/extensions/default/InlineTimingFunctionEditor/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, it, expect, beforeEach, afterEach, runs, waitsForDone */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/JSLint/unittests.js
+++ b/src/extensions/default/JSLint/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, it, expect, beforeEach, afterEach, runs, waitsForDone, spyOn */
-
 define(function (require, exports, module) {
     "use strict";
 
@@ -34,8 +32,10 @@ define(function (require, exports, module) {
         var testFolder = FileUtils.getNativeModuleDirectoryPath(module) + "/unittest-files/",
             testWindow,
             $,
+            // eslint-disable-next-line no-unused-vars
             brackets,
             CodeInspection,
+            // eslint-disable-next-line no-unused-vars
             EditorManager;
 
         var toggleJSLintResults = function (visible) {

--- a/src/extensions/default/JavaScriptCodeHints/Session.js
+++ b/src/extensions/default/JavaScriptCodeHints/Session.js
@@ -466,6 +466,7 @@ define(function (require, exports, module) {
             context          = null,
             cursor           = this.getCursor(),
             token            = this.getToken(cursor),
+            // eslint-disable-next-line no-unused-vars
             lexical;
 
         if (token) {

--- a/src/extensions/default/JavaScriptCodeHints/unittests.js
+++ b/src/extensions/default/JavaScriptCodeHints/unittests.js
@@ -23,7 +23,6 @@
  */
 
 /*jslint regexp: true */
-/*global describe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, waitsForDone, beforeFirst, afterLast */
 
 define(function (require, exports, module) {
     "use strict";

--- a/src/extensions/default/JavaScriptQuickEdit/unittests.js
+++ b/src/extensions/default/JavaScriptQuickEdit/unittests.js
@@ -22,14 +22,14 @@
  *
  */
 
-/*global describe, it, xit, expect, beforeEach, afterEach, waitsFor, runs, waitsForDone */
-
 define(function (require, exports, module) {
     "use strict";
 
+    // eslint-disable-next-line no-unused-vars
     var CommandManager,         // loaded from brackets.test
         EditorManager,          // loaded from brackets.test
         PerfUtils,              // loaded from brackets.test
+        // eslint-disable-next-line no-unused-vars
         JSUtils,                // loaded from brackets.test
 
         FileUtils           = brackets.getModule("file/FileUtils"),

--- a/src/extensions/default/MDNDocs/unittests.js
+++ b/src/extensions/default/MDNDocs/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, it, expect, beforeEach, afterEach, waitsFor, runs, waitsForDone, waitsForFail */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/NavigationAndHistory/main.js
+++ b/src/extensions/default/NavigationAndHistory/main.js
@@ -31,12 +31,10 @@ define(function (require, exports, module) {
         Strings                 = brackets.getModule("strings"),
         MainViewManager         = brackets.getModule("view/MainViewManager"),
         DocumentManager         = brackets.getModule("document/DocumentManager"),
-        DocumentCommandHandlers = brackets.getModule("document/DocumentCommandHandlers"),
         EditorManager           = brackets.getModule("editor/EditorManager"),
         ProjectManager          = brackets.getModule("project/ProjectManager"),
         CommandManager          = brackets.getModule("command/CommandManager"),
         Commands                = brackets.getModule("command/Commands"),
-        Dialogs                 = brackets.getModule("widgets/Dialogs"),
         Menus                   = brackets.getModule("command/Menus"),
         FileSystem              = brackets.getModule("filesystem/FileSystem"),
         FileUtils               = brackets.getModule("file/FileUtils"),
@@ -378,7 +376,7 @@ define(function (require, exports, module) {
     function _createMROFDisplayList(refresh) {
         var $def = $.Deferred();
 
-        var $mrofList, $link, $newItem;
+        var $mrofList;
 
         /**
          * Clears the MROF list in memory and pop over but retains the working set entries
@@ -431,8 +429,6 @@ define(function (require, exports, module) {
                 hideOnOpenFile: true
             });
         }
-
-        var data, fileEntry;
 
         _syncWithFileSystem().always(function () {
             _mrofList = _mrofList.filter(function (e) {return e; });
@@ -559,8 +555,6 @@ define(function (require, exports, module) {
         var index = _.findIndex(_mrofList, function (record) {
             return (record.file === filePath && record.paneId === paneId);
         });
-
-        var entry;
 
         if (index !== -1) {
             _mrofList[index].cursor = cursorPos;

--- a/src/extensions/default/PrefsCodeHints/unittests.js
+++ b/src/extensions/default/PrefsCodeHints/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, beforeEach, afterEach, it, expect*/
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/QuickOpenHTML/main.js
+++ b/src/extensions/default/QuickOpenHTML/main.js
@@ -27,8 +27,7 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var EditorManager       = brackets.getModule("editor/EditorManager"),
-        QuickOpen           = brackets.getModule("search/QuickOpen"),
+    var QuickOpen           = brackets.getModule("search/QuickOpen"),
         QuickOpenHelper     = brackets.getModule("search/QuickOpenHelper"),
         DocumentManager     = brackets.getModule("document/DocumentManager"),
         StringMatch         = brackets.getModule("utils/StringMatch");

--- a/src/extensions/default/QuickOpenJavaScript/main.js
+++ b/src/extensions/default/QuickOpenJavaScript/main.js
@@ -25,8 +25,7 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var EditorManager       = brackets.getModule("editor/EditorManager"),
-        QuickOpen           = brackets.getModule("search/QuickOpen"),
+    var QuickOpen           = brackets.getModule("search/QuickOpen"),
         QuickOpenHelper     = brackets.getModule("search/QuickOpenHelper"),
         JSUtils             = brackets.getModule("language/JSUtils"),
         DocumentManager     = brackets.getModule("document/DocumentManager"),
@@ -63,7 +62,6 @@ define(function (require, exports, module) {
 
         var functionList = [];
         var docText = doc.getText();
-        var lines = docText.split("\n");
         var functions = JSUtils.findAllMatchingFunctionsInText(docText, "*");
         functions.forEach(function (funcEntry) {
             functionList.push(new FileLocation(null, funcEntry.nameLineStart, funcEntry.columnStart, funcEntry.columnEnd, funcEntry.label || funcEntry.name));

--- a/src/extensions/default/QuickView/unittests.js
+++ b/src/extensions/default/QuickView/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, it, expect, beforeEach, runs, waitsForDone */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/RecentProjects/unittests.js
+++ b/src/extensions/default/RecentProjects/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, it, expect, beforeFirst, afterLast, runs, waitsFor, spyOn */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/SVGCodeHints/unittests.js
+++ b/src/extensions/default/SVGCodeHints/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, beforeEach, afterEach, it, expect */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/StaticServer/unittests.js
+++ b/src/extensions/default/StaticServer/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, it, xit, expect, beforeEach, afterEach, waits, waitsFor, waitsForDone, runs, waitsForDone, spyOn */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/extensions/default/UrlCodeHints/unittests.js
+++ b/src/extensions/default/UrlCodeHints/unittests.js
@@ -22,8 +22,6 @@
  *
  */
 
-/*global describe, it, expect, beforeEach, afterEach, beforeFirst, afterLast, waitsFor, runs, waitsForDone */
-
 define(function (require, exports, module) {
     "use strict";
 

--- a/src/filesystem/impls/appshell/node/FileWatcherDomain.js
+++ b/src/filesystem/impls/appshell/node/FileWatcherDomain.js
@@ -27,7 +27,6 @@
 
 "use strict";
 
-var os = require("os");
 var watcherManager = require("./FileWatcherManager");
 var watcherImpl;
 if (process.platform === "win32") {

--- a/src/help/HelpCommandHandlers.js
+++ b/src/help/HelpCommandHandlers.js
@@ -49,7 +49,7 @@ define(function (require, exports, module) {
 
     var buildInfo;
 
-
+    // eslint-disable-next-line no-unused-vars
     function _handleCheckForUpdates() {
         UpdateNotification.checkForUpdate(true);
     }

--- a/src/language/CSSUtils.js
+++ b/src/language/CSSUtils.js
@@ -734,7 +734,11 @@ define(function (require, exports, module) {
      */
     function extractAllSelectors(text, documentMode) {
         var state, lines, lineCount,
-            token, style, stream, line,
+            token,
+            // eslint-disable-next-line no-unused-vars
+            style,
+            stream,
+            line,
             selectors              = [],
             mode                   = CodeMirror.getMode({indentUnit: 2}, documentMode || "css"),
             currentSelector        = "",

--- a/src/language/HTMLInstrumentation.js
+++ b/src/language/HTMLInstrumentation.js
@@ -91,7 +91,6 @@ define(function (require, exports, module) {
 
     function getPositionFromTagId(editor, tagId) {
         var marks = editor._codeMirror.getAllMarks(),
-            i,
             markFound;
 
         markFound = _.find(marks, function (mark) {

--- a/src/language/HTMLSimpleDOM.js
+++ b/src/language/HTMLSimpleDOM.js
@@ -302,7 +302,11 @@ define(function (require, exports, module) {
      */
     Builder.prototype.build = function (strict, markCache) {
         var self = this;
-        var token, lastClosedTag, lastTextNode, lastIndex = 0;
+        var token,
+            lastClosedTag,
+            lastTextNode,
+            // eslint-disable-next-line no-unused-vars
+            lastIndex = 0;
         var stack = this.stack;
         var attributeName = null;
         var nodeMap = {};

--- a/src/language/JSUtils.js
+++ b/src/language/JSUtils.js
@@ -61,8 +61,7 @@ define(function (require, exports, module) {
             results = {},
             functionName,
             resultNode,
-            memberPrefix,
-            match;
+            memberPrefix;
 
         PerfUtils.markStart(PerfUtils.JSUTILS_REGEXP);
 

--- a/src/preferences/PreferencesManager.js
+++ b/src/preferences/PreferencesManager.js
@@ -22,7 +22,6 @@
  *
  */
 
-/*global define, console */
 /*unittests: Preferences Manager */
 
 /**

--- a/src/project/WorkingSetView.js
+++ b/src/project/WorkingSetView.js
@@ -335,6 +335,7 @@ define(function (require, exports, module) {
                     gTop,
                     gHeight,
                     gBottom,
+                    // eslint-disable-next-line no-unused-vars
                     deltaY,
                     containerOffset,
                     scrollerTopArea,

--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -55,6 +55,7 @@ define(function (require, exports, module) {
         intervalId = 0,
         lastQueriedText = "",
         lastTypedText = "",
+        // eslint-disable-next-line no-unused-vars
         lastKeyCode;
 
     /**
@@ -296,7 +297,6 @@ define(function (require, exports, module) {
         FindBar._addFindBar(this);
 
         var $root = this._modalBar.getRoot();
-        var historyIndex = 0;
         $root
             .on("input", "#find-what", function () {
                 self.trigger("queryChange");
@@ -376,7 +376,6 @@ define(function (require, exports, module) {
                         // if Shift is held down).
                         self.trigger("doFind", e.shiftKey);
                     }
-                    historyIndex = 0;
                 } else if (e.keyCode === KeyEvent.DOM_VK_DOWN || e.keyCode === KeyEvent.DOM_VK_UP) {
                     var quickSearchContainer = $(".quick-search-container");
                     if (!self.searchField) {

--- a/src/search/QuickOpenHelper.js
+++ b/src/search/QuickOpenHelper.js
@@ -25,10 +25,7 @@
 define(function (require, exports, module) {
     "use strict";
 
-    var EditorManager       = require("editor/EditorManager"),
-        QuickOpen           = require("search/QuickOpen"),
-        DocumentManager     = require("document/DocumentManager"),
-        StringMatch         = require("utils/StringMatch");
+    var EditorManager       = require("editor/EditorManager");
 
     /**
      * @param {string} query what the user is searching for

--- a/src/search/node/FindInFilesDomain.js
+++ b/src/search/node/FindInFilesDomain.js
@@ -24,7 +24,6 @@
 
 /*eslint-env node */
 /*jslint node: true */
-/*global setImmediate */
 "use strict";
 
 var fs = require("fs"),

--- a/src/utils/NodeConnection.js
+++ b/src/utils/NodeConnection.js
@@ -554,7 +554,6 @@ define(function (require, exports, module) {
                 var domainSpec = spec[domainKey];
                 self.domains[domainKey] = {};
                 Object.keys(domainSpec.commands).forEach(function (commandKey) {
-                    var commandSpec = domainSpec.commands[commandKey];
                     self.domains[domainKey][commandKey] = makeCommandFunction(domainKey, commandKey);
                 });
                 self.domainEvents[domainKey] = {};

--- a/src/utils/Resizer.js
+++ b/src/utils/Resizer.js
@@ -63,8 +63,7 @@ define(function (require, exports, module) {
         ViewUtils               = require("utils/ViewUtils"),
         PreferencesManager      = require("preferences/PreferencesManager");
 
-    var $mainView,
-        $sideBar;
+    var $sideBar;
 
     var isResizing = false,
         isWindowResizing = false;
@@ -524,8 +523,7 @@ define(function (require, exports, module) {
 
     function updateResizeLimits() {
         var sideBarMaxSize = _sideBarMaxSize(),
-            maxSize = $sideBar.data("maxsize"),
-            width = false;
+            maxSize = $sideBar.data("maxsize");
 
         if (maxSize !== undefined && _isPercentage(maxSize)) {
             sideBarMaxSize = _percentageToPixels(maxSize, sideBarMaxSize);
@@ -566,7 +564,6 @@ define(function (require, exports, module) {
     AppInit.htmlReady(function () {
         var minSize = DEFAULT_MIN_SIZE;
 
-        $mainView = $(".main-view");
         $sideBar = $("#sidebar");
 
         $(".vert-resizable").each(function (index, element) {

--- a/tasks/npm-install.js
+++ b/tasks/npm-install.js
@@ -30,7 +30,6 @@
 module.exports = function (grunt) {
 
     var _       = require("lodash"),
-        build   = require("./build")(grunt),
         common  = require("./lib/common")(grunt),
         exec    = require("child_process").exec,
         _spawn  = require("child_process").spawn,
@@ -173,7 +172,10 @@ module.exports = function (grunt) {
     grunt.registerTask("npm-install-src", "Install node_modules to the src folder", function () {
         var done = this.async();
         runNpmInstall("src", function (err) {
-
+            if (err) {
+                done(false);
+            }
+            done();
         });
     });
 

--- a/tasks/npm-shrinkwrap.js
+++ b/tasks/npm-shrinkwrap.js
@@ -28,11 +28,7 @@
 
 module.exports = function (grunt) {
 
-    var _       = require("lodash"),
-        common  = require("./lib/common")(grunt),
-        build   = require("./build")(grunt),
-        glob    = require("glob"),
-        path    = require("path"),
+    var common  = require("./lib/common")(grunt),
         exec    = require("child_process").exec;
 
     function runNpmShrinkwrap(callback) {

--- a/tasks/pack-web-dependencies.js
+++ b/tasks/pack-web-dependencies.js
@@ -5,9 +5,6 @@
 module.exports = function (grunt) {
 
     var _       = require("lodash"),
-        common  = require("./lib/common")(grunt),
-        build   = require("./build")(grunt),
-        glob    = require("glob"),
         path    = require("path"),
         spawn   = require("child_process").spawn;
 

--- a/tasks/sync-tsconfigs.js
+++ b/tasks/sync-tsconfigs.js
@@ -4,9 +4,6 @@
 
 module.exports = function (grunt) {
     const common    = require("./lib/common")(grunt);
-    const build     = require("./build")(grunt);
-    const fs        = require("fs");
-    const path      = require("path");
     const _         = require("lodash");
 
     // sync-tsconfigs

--- a/tasks/webpack.js
+++ b/tasks/webpack.js
@@ -5,9 +5,6 @@
 module.exports = function (grunt) {
 
     var _       = require("lodash"),
-        common  = require("./lib/common")(grunt),
-        build   = require("./build")(grunt),
-        glob    = require("glob"),
         path    = require("path"),
         spawn   = require("cross-spawn");
 

--- a/test/SpecRunner.js
+++ b/test/SpecRunner.js
@@ -107,6 +107,7 @@ define(function (require, exports, module) {
     var selectedSuites,
         params          = new UrlParams(),
         reporter,
+        // eslint-disable-next-line no-unused-vars
         reporterView,
         _writeResults   = new $.Deferred(),
         resultsPath;

--- a/test/perf/Performance-test.js
+++ b/test/perf/Performance-test.js
@@ -30,9 +30,11 @@ define(function (require, exports, module) {
     // Load dependent modules
     var CommandManager,             // loaded from brackets.test
         Commands,                   // loaded from brackets.test
+        /* eslint-disable no-unused-vars */
         DocumentCommandHandlers,    // loaded from brackets.test
         PerfUtils,                  // loaded from brackets.test
         DocumentManager,            // loaded from brackets.test
+        /* eslint-enable no-unused-vars */
         SpecRunnerUtils             = require("spec/SpecRunnerUtils"),
         UnitTestReporter            = require("test/UnitTestReporter");
 

--- a/test/spec/CSSInlineEdit-test.js
+++ b/test/spec/CSSInlineEdit-test.js
@@ -42,6 +42,7 @@ define(function (require, exports, module) {
             DocumentManager,
             PreferencesManager,
             Commands,
+            // eslint-disable-next-line no-unused-vars
             FileSystem,
             Dialogs;
 

--- a/test/spec/CSSUtils-test.js
+++ b/test/spec/CSSUtils-test.js
@@ -728,6 +728,7 @@ define(function (require, exports, module) {
 
         var lastCssCode,
             match,
+            // eslint-disable-next-line no-unused-vars
             expectParseError;
 
         function _findMatchingRules(cssCode, tagInfo, mode) {

--- a/test/spec/Document-test.js
+++ b/test/spec/Document-test.js
@@ -238,6 +238,7 @@ define(function (require, exports, module) {
 
         var testPath = SpecRunnerUtils.getTestPath("/spec/Document-test-files"),
             testWindow,
+            // eslint-disable-next-line no-unused-vars
             $;
 
         beforeFirst(function () {
@@ -545,6 +546,7 @@ define(function (require, exports, module) {
             it("should clean up (later) a master Editor auto-created by calling read-only Document API, if Editor not used by UI", function () {
                 var promise,
                     cssDoc,
+                    // eslint-disable-next-line no-unused-vars
                     cssMasterEditor;
 
                 runs(function () {

--- a/test/spec/DocumentCommandHandlers-test.js
+++ b/test/spec/DocumentCommandHandlers-test.js
@@ -137,12 +137,10 @@ define(function (require, exports, module) {
 
 
         describe("New Untitled File", function () {
-            var filePath,
-                newFilename,
+            var newFilename,
                 newFilePath;
 
             beforeEach(function () {
-                filePath    = testPath + "/test.js";
                 newFilename = "testname.js";
                 newFilePath = testPath + "/" + newFilename;
             });

--- a/test/spec/DocumentManager-test.js
+++ b/test/spec/DocumentManager-test.js
@@ -29,6 +29,7 @@ define(function (require, exports, module) {
     var CommandManager,          // loaded from brackets.test
         Commands,                // loaded from brackets.test
         DocumentManager,         // loaded from brackets.test
+        // eslint-disable-next-line no-unused-vars
         EditorManager,           // loaded from brackets.test
         SpecRunnerUtils          = require("spec/SpecRunnerUtils");
 
@@ -39,6 +40,7 @@ define(function (require, exports, module) {
         var testPath = SpecRunnerUtils.getTestPath("/spec/DocumentCommandHandlers-test-files"),
             testFile = testPath + "/test.js",
             testWindow,
+            // eslint-disable-next-line no-unused-vars
             _$,
             promise;
 

--- a/test/spec/DragAndDrop-test.js
+++ b/test/spec/DragAndDrop-test.js
@@ -26,6 +26,7 @@ define(function (require, exports, module) {
     "use strict";
 
     // Load dependent modules
+    // eslint-disable-next-line no-unused-vars
     var DocumentManager,      // loaded from brackets.test
         DragAndDrop,          // loaded from brackets.test
         EditorManager,        // loaded from brackets.test

--- a/test/spec/EditorManager-test.js
+++ b/test/spec/EditorManager-test.js
@@ -30,7 +30,7 @@ define(function (require, exports, module) {
         SpecRunnerUtils  = require("spec/SpecRunnerUtils");
 
     describe("EditorManager", function () {
-        var pane, anotherPane, testEditor, testDoc, $fakeContentDiv, $fakeHolder;
+        var pane, anotherPane, testDoc, $fakeContentDiv, $fakeHolder;
         beforeEach(function () {
             // Normally the editor holder would be created inside a "content" div, which is
             // used in the available height calculation. We create a fake content div just to
@@ -56,7 +56,6 @@ define(function (require, exports, module) {
             $fakeContentDiv = null;
 
             SpecRunnerUtils.destroyMockEditor(testDoc);
-            testEditor = null;
             testDoc = null;
             pane = null;
             ViewStateManager.reset();
@@ -101,7 +100,11 @@ define(function (require, exports, module) {
         });
     });
     describe("ViewStateManager", function () {
-        var pane, testEditor, testDoc, $fakeContentDiv, $fakeHolder;
+        // eslint-disable-next-line no-unused-vars
+        var pane,
+            testDoc,
+            $fakeContentDiv,
+            $fakeHolder;
         beforeEach(function () {
             // Normally the editor holder would be created inside a "content" div, which is
             // used in the available height calculation. We create a fake content div just to
@@ -126,7 +129,6 @@ define(function (require, exports, module) {
             $fakeContentDiv = null;
 
             SpecRunnerUtils.destroyMockEditor(testDoc);
-            testEditor = null;
             testDoc = null;
             pane = null;
             ViewStateManager.reset();

--- a/test/spec/EditorOptionHandlers-test.js
+++ b/test/spec/EditorOptionHandlers-test.js
@@ -29,6 +29,7 @@ define(function (require, exports, module) {
     var CommandManager,      // loaded from brackets.test
         Commands,            // loaded from brackets.test
         EditorManager,       // loaded from brackets.test
+        // eslint-disable-next-line no-unused-vars
         DocumentManager,     // loaded from brackets.test
         FileViewController,
         SpecRunnerUtils     = require("spec/SpecRunnerUtils");

--- a/test/spec/ExtensionManager-test.js
+++ b/test/spec/ExtensionManager-test.js
@@ -57,7 +57,7 @@ define(function (require, exports, module) {
 
     describe("ExtensionManager", function () {
         var mockId, mockSettings, origRegistryURL, origExtensionUrl, removedPath,
-            view, model, fakeLoadDeferred, modelDisposed, disabledFilePath;
+            view, model, fakeLoadDeferred, disabledFilePath;
 
         beforeEach(function () {
             // Use fake URLs for the registry (useful if the registry isn't actually currently
@@ -213,7 +213,6 @@ define(function (require, exports, module) {
             runs(function () {
                 view = new ExtensionManagerView();
                 model = new ModelClass();
-                modelDisposed = false;
                 waitsForDone(view.initialize(model), "view initializing");
                 view.$el.appendTo(window.document.body);
             });

--- a/test/spec/FileFilters-test.js
+++ b/test/spec/FileFilters-test.js
@@ -494,6 +494,7 @@ define(function (require, exports, module) {
                 FileSystem,
                 FindInFiles,
                 FindInFilesUI,
+                // eslint-disable-next-line no-unused-vars
                 CommandManager,
                 $;
 

--- a/test/spec/FileTreeView-test.js
+++ b/test/spec/FileTreeView-test.js
@@ -309,8 +309,7 @@ define(function (require, exports, module) {
                     })
                 };
                 var rendered = RTU.renderIntoDocument(FileTreeView._directoryNode(props));
-                var dirLI = ReactDOM.findDOMNode(rendered),
-                    dirA = $(dirLI).find("a")[0];
+                var dirLI = ReactDOM.findDOMNode(rendered);
 
                 expect(dirLI.children[1].textContent).toBe(" thedir");
                 expect(FileTreeView._fullPath(props)).toBe("/foo/thedir/");

--- a/test/spec/FileTreeViewModel-test.js
+++ b/test/spec/FileTreeViewModel-test.js
@@ -657,6 +657,7 @@ define(function (require, exports, module) {
 
         describe("createPlaceholder", function () {
             var vm = new FileTreeViewModel.FileTreeViewModel(),
+                // eslint-disable-next-line no-unused-vars
                 changesFired;
 
             vm.on(FileTreeViewModel.EVENT_CHANGE, function () {

--- a/test/spec/FindInFiles-test.js
+++ b/test/spec/FindInFiles-test.js
@@ -446,7 +446,6 @@ define(function (require, exports, module) {
                 executeSearch("foo5");
 
                 runs(function () {
-                    var searchHistory = PreferencesManager.getViewState("searchHistory");
                     var $searchField = $("#find-what");
 
                     $("#find-what").val("");
@@ -467,7 +466,6 @@ define(function (require, exports, module) {
                 executeSearch("foo5");
 
                 runs(function () {
-                    var searchHistory = PreferencesManager.getViewState("searchHistory");
                     var $searchField = $("#find-what");
 
                     $("#find-what").val("");

--- a/test/spec/HTMLInstrumentation-test.js
+++ b/test/spec/HTMLInstrumentation-test.js
@@ -2072,6 +2072,7 @@ define(function (require, exports, module) {
             it("should represent simple new tag insert immediately after previous tag before text before tag", function () {
                 setupEditor(WellFormedDoc);
                 runs(function () {
+                    // eslint-disable-next-line no-unused-vars
                     var ed;
 
                     doFullAndIncrementalEditTest(

--- a/test/spec/InlineEditorProviders-test.js
+++ b/test/spec/InlineEditorProviders-test.js
@@ -31,6 +31,7 @@ define(function (require, exports, module) {
         FileSyncManager,    // loaded from brackets.test
         DocumentManager,    // loaded from brackets.test
         MainViewManager,    // loaded from brackets.test
+        // eslint-disable-next-line no-unused-vars
         FileViewController, // loaded from brackets.test
         InlineWidget     = require("editor/InlineWidget").InlineWidget,
         Dialogs          = require("widgets/Dialogs"),
@@ -507,8 +508,7 @@ define(function (require, exports, module) {
                 initInlineTest("test1.html", 0);
 
                 runs(function () {
-                    var hostEditor = EditorManager.getCurrentFullEditor(),
-                        inlineWidget = hostEditor.getInlineWidgets()[0];
+                    var hostEditor = EditorManager.getCurrentFullEditor();
 
                     // verify inline widget
                     expect(hostEditor.getInlineWidgets().length).toBe(1);
@@ -522,7 +522,7 @@ define(function (require, exports, module) {
                     // verify no inline widgets
                     expect(hostEditor.getInlineWidgets().length).toBe(0);
 
-                    doc = hostEditor = inlineWidget = null;
+                    doc = hostEditor = null;
                 });
             });
 
@@ -796,6 +796,7 @@ define(function (require, exports, module) {
             it("should save changes in the inline editor", function () {
                 initInlineTest("test1.html", 1);
 
+                // eslint-disable-next-line no-unused-vars
                 var err = false,
                     hostEditor,
                     inlineEditor,
@@ -865,6 +866,7 @@ define(function (require, exports, module) {
             it("should not save changes in the host editor", function () {
                 initInlineTest("test1.html", 1);
 
+                // eslint-disable-next-line no-unused-vars
                 var err = false,
                     hostEditor,
                     inlineEditor,
@@ -1054,11 +1056,10 @@ define(function (require, exports, module) {
                 it("should add dirty documents to the working set", function () {
                     initInlineTest("test1.html", 1);
 
-                    var inlineEditor, widgetHeight;
+                    var inlineEditor;
 
                     runs(function () {
                         inlineEditor = EditorManager.getCurrentFullEditor().getInlineWidgets()[0].editor;
-                        widgetHeight = inlineEditor.totalHeight();
 
                         // change inline editor content
                         var newLines = ".bar {\ncolor: #f00;\n}\n.cat {\ncolor: #f00;\n}";

--- a/test/spec/JSONUtils-test.js
+++ b/test/spec/JSONUtils-test.js
@@ -29,7 +29,7 @@ define(function (require, exports, module) {
         JSONUtils            = require("language/JSONUtils");
 
     describe("JSONUtils", function () {
-        var mockEditor, testContent, testDocument, testEditor, ctxInfo;
+        var mockEditor, testContent, testEditor, ctxInfo;
 
         // A sample preferences file to run tests against.
         testContent =   "{\n" +
@@ -68,11 +68,9 @@ define(function (require, exports, module) {
                 endLine: 30
             });
             testEditor = mockEditor.editor;
-            testDocument = mockEditor.doc;
         });
         afterEach(function () {
             testEditor.destroy();
-            testDocument = null;
             ctxInfo = null;
         });
 

--- a/test/spec/KeyBindingManager-test.js
+++ b/test/spec/KeyBindingManager-test.js
@@ -42,6 +42,7 @@ define(function (require, exports, module) {
 
     var testPath            = SpecRunnerUtils.getTestPath("/spec/KeyBindingManager-test-files");
 
+    // eslint-disable-next-line no-unused-vars
     var executed,
         testCommandFn       = function () { executed = true; };
 

--- a/test/spec/LiveDevelopment-test.js
+++ b/test/spec/LiveDevelopment-test.js
@@ -42,11 +42,13 @@ define(function (require, exports, module) {
     var CommandManager,
         Commands,
         Dialogs,
+        // eslint-disable-next-line no-unused-vars
         NativeApp,
         LiveDevelopment,
         Inspector,
         DOMAgent,
         DocumentManager,
+        // eslint-disable-next-line no-unused-vars
         ProjectManager;
 
     // Used as mocks
@@ -272,6 +274,7 @@ define(function (require, exports, module) {
 
             var testDocument,
                 testEditor,
+                // eslint-disable-next-line no-unused-vars
                 testCSSDoc,
                 liveDevelopmentConfig,
                 inspectorConfig;
@@ -356,6 +359,7 @@ define(function (require, exports, module) {
 
             var testDocument,
                 testEditor,
+                // eslint-disable-next-line no-unused-vars
                 testCSSDoc,
                 liveDevelopmentConfig,
                 inspectorConfig,
@@ -456,6 +460,7 @@ define(function (require, exports, module) {
 
             var testDocument,
                 testEditor,
+                // eslint-disable-next-line no-unused-vars
                 testCSSDoc,
                 liveDevelopmentConfig,
                 inspectorConfig,

--- a/test/spec/LiveDevelopmentMultiBrowser-test.js
+++ b/test/spec/LiveDevelopmentMultiBrowser-test.js
@@ -35,6 +35,7 @@ define(function (require, exports, module) {
             brackets,
             DocumentManager,
             LiveDevelopment,
+            // eslint-disable-next-line no-unused-vars
             LiveDevProtocol;
 
         var testFolder = SpecRunnerUtils.getTestPath("/spec/LiveDevelopment-MultiBrowser-test-files"),

--- a/test/spec/LowLevelFileIO-test.js
+++ b/test/spec/LowLevelFileIO-test.js
@@ -714,15 +714,12 @@ define(function (require, exports, module) {
         });
 
         describe("rename", function () {
-            var complete;
 
             it("should rename a file", function () {
                 var oldName     = baseDir + "/file_one.txt",
                     newName     = baseDir + "/file_one_renamed.txt",
                     renameCB    = errSpy(),
                     statCB      = statSpy();
-
-                complete = false;
 
                 runs(function () {
                     brackets.fs.rename(oldName, newName, renameCB);
@@ -775,8 +772,6 @@ define(function (require, exports, module) {
                     renameCB    = errSpy(),
                     statCB      = statSpy();
 
-                complete = false;
-
                 runs(function () {
                     brackets.fs.rename(oldName, newName, renameCB);
                 });
@@ -826,8 +821,6 @@ define(function (require, exports, module) {
                     newName = baseDir + "/file_two.txt",
                     cb      = errSpy();
 
-                complete = false;
-
                 runs(function () {
                     brackets.fs.rename(oldName, newName, cb);
                 });
@@ -844,8 +837,6 @@ define(function (require, exports, module) {
                         newName = baseDir + "/cant_write_here/readme_renamed.txt",
                         cb      = errSpy();
 
-                    complete = false;
-
                     runs(function () {
                         brackets.fs.rename(oldName, newName, cb);
                     });
@@ -861,7 +852,6 @@ define(function (require, exports, module) {
         });
 
         describe("copyFile", function () {
-            var complete;
 
             it("should copy a file", function () {
                 var fileName     = baseDir + "/file_one.txt",
@@ -869,8 +859,6 @@ define(function (require, exports, module) {
                     copyCB       = errSpy(),
                     unlinkCB     = errSpy(),
                     statCB       = statSpy();
-
-                complete = false;
 
                 // Verify new file does not exist
                 runs(function () {

--- a/test/spec/MainViewFactory-test.js
+++ b/test/spec/MainViewFactory-test.js
@@ -32,15 +32,20 @@ define(function (require, exports, module) {
 
         var CommandManager,          // loaded from brackets.test
             Commands,                // loaded from brackets.test
+            // eslint-disable-next-line no-unused-vars
             DocumentManager,         // loaded from brackets.test
+            // eslint-disable-next-line no-unused-vars
             EditorManager,           // loaded from brackets.test
             MainViewManager,         // loaded from brackets.test
+            // eslint-disable-next-line no-unused-vars
             ProjectManager,          // loaded from brackets.test
             FileSystem,              // loaded from brackets.test
+            // eslint-disable-next-line no-unused-vars
             Dialogs;                 // loaded from brackets.test
 
         var testPath = SpecRunnerUtils.getTestPath("/spec/MainViewFactory-test-files"),
             testWindow,
+            // eslint-disable-next-line no-unused-vars
             _$,
             promise;
 

--- a/test/spec/Menu-test.js
+++ b/test/spec/Menu-test.js
@@ -604,6 +604,7 @@ define(function (require, exports, module) {
                 var listSelector = "#menuitem-unittest1 > ul";
 
                 // Add new menu to END of menuSectionCmd0
+                // eslint-disable-next-line no-unused-vars
                 var menuItem = menu.addMenuItem("Menu-test.command14", null, Menus.LAST_IN_SECTION, menuSectionCmd0);
                 var $listItems = testWindow.$(listSelector).children();
                 expect($listItems.length).toBe(6);
@@ -796,6 +797,7 @@ define(function (require, exports, module) {
                     expect(Object.keys(command._eventHandlers).length).toBe(1);
                     expect(command._eventHandlers.nameChange.length).toBe(1);
 
+                    // eslint-disable-next-line no-unused-vars
                     var menuItem = menu.addMenuItem(commandId);
                     expect(Object.keys(command._eventHandlers).length).toBe(5);
                     expect(command._eventHandlers.nameChange.length).toBe(2);

--- a/test/spec/NativeMenu-test.js
+++ b/test/spec/NativeMenu-test.js
@@ -944,6 +944,7 @@ define(function (require, exports, module) {
                 var complete,
                     error,
                     index,
+                    // eslint-disable-next-line no-unused-vars
                     parent;
 
                 // set up test menu and menu items

--- a/test/spec/PreferencesBase-test.js
+++ b/test/spec/PreferencesBase-test.js
@@ -1438,6 +1438,7 @@ define(function (require, exports, module) {
             var settingsFile      = FileSystem.getFileForPath(testPath + "/.brackets.json"),
                 newSettingsFile   = FileSystem.getFileForPath(testPath + "/new.prefs"),
                 emptySettingsFile = FileSystem.getFileForPath(testPath + "/empty.json"),
+                // eslint-disable-next-line no-unused-vars
                 filestorage,
                 originalText;
 

--- a/test/spec/ProjectManager-test.js
+++ b/test/spec/ProjectManager-test.js
@@ -375,7 +375,6 @@ define(function (require, exports, module) {
                     rootFolderName  = tempDir + "/toDelete1/",
                     rootFolderEntry = FileSystem.getDirectoryForPath(rootFolderName),
                     error,
-                    stat,
                     promise;
 
                 // Delete the root folder and all files/folders in it.
@@ -390,7 +389,6 @@ define(function (require, exports, module) {
                     complete = false;
                     rootFolder.stat(function (err, _stat) {
                         error = err;
-                        stat = _stat;
                         complete = true;
                     });
                 });

--- a/test/spec/ProjectModel-test.js
+++ b/test/spec/ProjectModel-test.js
@@ -385,7 +385,6 @@ define(function (require, exports, module) {
             var model = new ProjectModel.ProjectModel(),
                 vm = model._viewModel,
                 changesFired,
-                selectionsMade,
                 creationErrors,
                 focusEvents,
                 selectionEvents;
@@ -417,7 +416,6 @@ define(function (require, exports, module) {
                 changesFired = 0;
                 focusEvents = 0;
                 creationErrors = [];
-                selectionsMade = [];
                 selectionEvents = [];
                 vm._treeData = Immutable.fromJS({
                     subdir1: {


### PR DESCRIPTION
Disabled on many lines to avoid potentially side effects in removing the variable.