### PR TITLE
Fix for FindInFiles UI not opening when no file is open  (#14416)

### DIFF
--- a/src/search/FindBar.js
+++ b/src/search/FindBar.js
@@ -705,7 +705,7 @@ define(function (require, exports, module) {
      */
     FindBar.getInitialQuery = function (currentFindBar, editor) {
         var query,
-            selection = FindBar._getInitialQueryFromSelection(editor),
+            selection = editor ? FindBar._getInitialQueryFromSelection(editor) : "",
             replaceText = "";
 
         if (currentFindBar && !currentFindBar.isClosed()) {


### PR DESCRIPTION
* Add null check for editor

* Cleanup: Use tertiary operator