### PR TITLE
Add preference to hide Extension Manager by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+Don't show the Extension Manager by default (for now)
+
+
 ## v2.0.0-alpha.3 (2019-01-06)
 
 Add a paddingComment option

--- a/src/document/DocumentCommandHandlers.js
+++ b/src/document/DocumentCommandHandlers.js
@@ -1744,7 +1744,7 @@ define(function (require, exports, module) {
 
         params.parse();
 
-        if (params.get("reloadWithoutUserExts") === "true") {
+        if (params.get("reloadWithoutUserExts") === "true" || PreferencesManager.get("extensionManager.show") === false) {
             CommandManager.get(Commands.FILE_EXTENSION_MANAGER).setEnabled(false);
             $icon.css({display: "none"});
             StatusBar.addIndicator("status-user-exts", $indicator, true);

--- a/src/extensibility/ExtensionManager.js
+++ b/src/extensibility/ExtensionManager.js
@@ -112,6 +112,9 @@ define(function (require, exports, module) {
     PreferencesManager.definePreference("extensions.sort", "string", "publishedDate", {
         description: Strings.SORT_EXTENSION_METHOD
     });
+    PreferencesManager.definePreference("extensionManager.show", "boolean", false, {
+        description: Strings.DESCRIPTION_EXTENSION_MANAGER_SHOW
+    });
 
     /**
      * @private

--- a/src/nls/root/strings.js
+++ b/src/nls/root/strings.js
@@ -706,6 +706,7 @@ define({
     "DESCRIPTION_CODE_FOLDING_MIN_FOLD_SIZE"         : "Minimum lines before a collapsible section icon appears",
     "DESCRIPTION_CODE_FOLDING_SAVE_FOLD_STATES"      : "true to remember collapsed sections if you close and reopen a file or project",
     "DESCRIPTION_CODE_FOLDING_MAKE_SELECTIONS_FOLDABLE": "true to enable code folding on selected text in the editor",
+    "DESCRIPTION_EXTENSION_MANAGER_SHOW"             : "true to show the Extension Manager",
     "DESCRIPTION_DISABLED_DEFAULT_EXTENSIONS"        : "Default extensions that are disabled",
     "DESCRIPTION_ATTR_HINTS"                         : "Enable/disable HTML attribute hints",
     "DESCRIPTION_CSS_PROP_HINTS"                     : "Enable/disable CSS/LESS/SCSS property hints",


### PR DESCRIPTION
I plan some breaking changes so it is possible that extensions will not work anymore.
For now just hide the Extension Manager.