### PR TITLE
Implement appshell.app.getMachineHash

### DIFF
--- a/app/appshell/app.ts
+++ b/app/appshell/app.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import * as pathLib from "path";
 import * as utils from "../utils";
 import { remote, shell } from "electron";
+import { machineId } from "node-machine-id";
 
 const app = remote.app;
 const REMOTE_DEBUGGING_PORT = 9234; // TODO: this is hardcoded in brackets-shell
@@ -143,5 +144,13 @@ export function showOSFolder(
     process.nextTick(function () {
         shell.showItemInFolder(utils.convertBracketsPathToWindowsPath(path));
         if (callback) { callback(); }
+    });
+}
+
+export function getMachineHash(callback: (err: Error | null, macHash?: string) => void): void {
+    process.nextTick(function () {
+        machineId()
+            .then((id) => callback(null, id))
+            .catch((err) => callback(err));
     });
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11683,6 +11683,11 @@
         "vm-browserify": "^1.0.1"
       }
     },
+    "node-machine-id": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
+      "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ=="
+    },
     "node-pre-gyp": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "fs-extra": "^8.1.0",
     "isbinaryfile": "3.0.2",
     "lodash": "^4.17.15",
+    "node-machine-id": "^1.1.12",
     "npm": "^6.10.2",
     "opn": "4.0.2",
     "portscanner": "^2.2.0",

--- a/src/config.json
+++ b/src/config.json
@@ -154,6 +154,7 @@
         "fs-extra": "^8.1.0",
         "isbinaryfile": "3.0.2",
         "lodash": "^4.17.15",
+        "node-machine-id": "^1.1.12",
         "npm": "^6.10.2",
         "opn": "4.0.2",
         "portscanner": "^2.2.0",


### PR DESCRIPTION
Probably it is not the same of upstream, but since it is used for HealthDataManager it is fine.
In Quadre Health Report is not really important for now.
(and should be disabled by default if I remember correctly...)