### PR TITLE
Use brackets.min.css instead of brackets.less

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -37,13 +37,8 @@
     <script type="application/javascript" src="xorigin.js"></script>
 
     <link rel="stylesheet" type="text/css" href="thirdparty/CodeMirror/lib/codemirror.css">
-    <!--(if target dev)><!-->
-    <link rel="stylesheet/less" type="text/css" href="styles/brackets.less">
-    <!--<!(endif)-->
-    <!--(if target dist)>
     <link rel="stylesheet" type="text/css" href="styles/brackets.min.css">
-    <!--<!(endif)-->
-    
+
     <!-- JavaScript -->
 
     <!-- Pre-load third party scripts that cannot be async loaded. -->


### PR DESCRIPTION
At the moment *.less files are copied over but also compiled to *.css files at build time.
So we can reference the *.css one directly in index.html
This has also the side effect to speed up a bit the testsuite, since there isn't the needs to recompile them for every window opened.