### PR TITLE
Update check on buildNumber in InAppNotifications

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -20,10 +20,12 @@
         "linting.enabled_by_default": true,
         "build_timestamp": "",
         "healthDataServerURLs": [],
-        "analyticsDataServerURL": "https://cc-api-data.adobe.io/ingest",
+        "analyticsDataServerURL": "https://cc-api-data-stage.adobe.io/ingest",
         "serviceKey": "brackets-service",
         "environment": "stage",
-        "update_info_url": "https://s3.amazonaws.com/files.brackets.io/updates/prerelease/<locale>.json"
+        "update_info_url": "https://s3.amazonaws.com/files.brackets.io/updates/prerelease/<locale>.json",
+        "notification_info_url": "https://s3.amazonaws.com/files.brackets.io/notifications/prerelease/<locale>.json",
+        "buildtype": "dev"
     },
     "name": "quadre",
     "productName": "Quadre",

--- a/src/extensions/default/InAppNotifications/main.js
+++ b/src/extensions/default/InAppNotifications/main.js
@@ -255,12 +255,16 @@ define(function (require, exports, module) {
             _platform = brackets.getPlatformInfo(),
             _locale = brackets.getLocale(),
             _lastHandledNotificationNumber = PreferencesManager.getViewState("lastHandledNotificationNumber"),
-            // Extract current build number from package.json version field 0.0.0-0
-            _buildNumber = Number(/-([0-9]+)/.exec(brackets.metadata.version)[1]),
+            _buildNumber = "",
             _version = brackets.metadata.apiVersion;
 
         if (_locale.length > 2) {
             _locale = _locale.substring(0, 2);
+        }
+
+        // Extract current build number from package.json version field 0.0.0-0 (0) or 0.0.0-alpha.1 (alpha.1).
+        if (brackets.metadata.version.indexOf("-") >= 0) {
+            _buildNumber = brackets.metadata.version.substring(brackets.metadata.version.indexOf("-") + 1);
         }
 
         return  notificationObj.sequence > _lastHandledNotificationNumber &&


### PR DESCRIPTION
Quadre uses a little different versioning: at the moment its version end with "-alpha.x"

It also update the config urls (which should be revisited)