### PR TITLE
Disable no-console and max-len ESLint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     },
     "rules": {
         "guard-for-in": "off",
-        "max-len": ["warn", 120],
+        "max-len": "off",
         "new-cap": ["error", {
             capIsNewExceptions: [
                 "CodeMirror",
@@ -16,6 +16,7 @@ module.exports = {
                 "$.Event"
             ]
         }],
+        "no-console": "off",
         "no-invalid-this": "off",
         "no-shadow": "warn",
     },


### PR DESCRIPTION
At the momento they just create more noise than necessary